### PR TITLE
Feature | Observations field on task

### DIFF
--- a/backend/schema/resolvers/task/mutations.ts
+++ b/backend/schema/resolvers/task/mutations.ts
@@ -52,7 +52,7 @@ const TaskInputPothosRef = builder.inputType('TaskInput', {
 const UpdateMyTaskInput = builder.inputType('UpdateMyTaskInput', {
     fields: (t) => ({
         id: t.string({ required: true }),
-        workOrderNumber: t.string({ required: true }),
+        workOrderNumber: t.string({ required: false }),
         imageKeys: t.stringList({ required: true }),
         observations: t.string({ required: false }),
     }),
@@ -359,6 +359,7 @@ builder.mutationFields((t) => ({
                         status: true,
                         workOrderNumber: true,
                         imagesIDs: true,
+                        observations: true,
                     },
                 });
                 if (!foundTask) {
@@ -380,10 +381,11 @@ builder.mutationFields((t) => ({
                         id,
                     },
                     data: {
-                        workOrderNumber:
-                            parseInt(workOrderNumber, 10) ?? foundTask.workOrderNumber,
+                        workOrderNumber: workOrderNumber
+                            ? parseInt(workOrderNumber, 10)
+                            : foundTask.workOrderNumber,
                         status: TaskStatus.Finalizada,
-                        observations,
+                        observations: observations ?? foundTask.observations,
                         images: {
                             create: await Promise.all(
                                 imageKeys.map(async (key) => ({


### PR DESCRIPTION
added checks to see if the observations come undefined, and made the workOrderNumber field in the mutation input optional