### PR TITLE
"Implementación de formulario de creación de gastos en la aplicación web y funcionalidad de ordenamiento bidireccional (ascendente/descendente) para columnas"

### DIFF
--- a/backend/schema/resolvers/auth/mutations.ts
+++ b/backend/schema/resolvers/auth/mutations.ts
@@ -179,7 +179,12 @@ export const AuthMutations = builder.mutationFields((t) => ({
             }),
         },
         authz: {
-            rules: ['IsAuthenticated', 'IsAdministrativoTecnico'],
+            rules: [
+                'IsTecnico',
+                'IsAdministrativoContable',
+                'IsAdministrativoTecnico',
+                'IsAuditor',
+            ],
         },
         resolve: async (_parent, args) => {
             try {

--- a/backend/schema/resolvers/expense/mutations.ts
+++ b/backend/schema/resolvers/expense/mutations.ts
@@ -56,7 +56,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
             compositeRules: [
                 { and: ['IsAuthenticated'] },
                 {
-                    or: ['IsTecnico', 'IsAdministrativoTecnico', 'IsAuditor'],
+                    or: ['IsAdministrativoContable', 'IsAdministrativoTecnico'],
                 },
             ],
         },
@@ -135,7 +135,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
             compositeRules: [
                 { and: ['IsAuthenticated'] },
                 {
-                    or: ['IsTecnico'],
+                    or: ['IsAdministrativoContable', 'IsAdministrativoTecnico'],
                 },
             ],
         },
@@ -357,7 +357,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
                     and: ['IsAuthenticated'],
                 },
                 {
-                    or: ['IsAdministrativoContable'],
+                    or: ['IsAdministrativoContable', 'IsAdministrativoTecnico'],
                 },
             ],
         },
@@ -420,7 +420,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
         authz: {
             compositeRules: [
                 { and: ['IsAuthenticated'] },
-                { or: ['IsAdministrativoContable'] },
+                { or: ['IsAdministrativoContable', 'IsAdministrativoTecnico'] },
             ],
         },
         resolve: async (root, { startDate, endDate, filters }) => {
@@ -653,7 +653,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
                     and: ['IsAuthenticated'],
                 },
                 {
-                    or: ['IsAdministrativoContable'],
+                    or: ['IsAdministrativoContable', 'IsAdministrativoTecnico'],
                 },
             ],
         },

--- a/backend/schema/resolvers/file/mutations.ts
+++ b/backend/schema/resolvers/file/mutations.ts
@@ -1,8 +1,46 @@
 import { FileInputRef, FileCrudRef } from './refs';
 
+import { createUploadPresignedUrl } from 'backend/s3Client';
 import { prisma } from 'lib/prisma';
 
 import { builder } from '../../builder';
+
+// Crear un tipo para la información de URL
+const UploadUrlInfoRef = builder.objectRef<{
+    url: string;
+    key: string;
+    urlExpire: string;
+}>('UploadUrlInfo');
+
+builder.objectType(UploadUrlInfoRef, {
+    fields: (t) => ({
+        url: t.exposeString('url'),
+        key: t.exposeString('key'),
+        urlExpire: t.exposeString('urlExpire'),
+    }),
+});
+
+// Crear un tipo para la respuesta de URLs presignadas
+const PresignedUrlResponseRef = builder.objectRef<{
+    success: boolean;
+    message?: string;
+    uploadUrls: Array<{
+        url: string;
+        key: string;
+        urlExpire: string;
+    }>;
+}>('PresignedUrlResponse');
+
+builder.objectType(PresignedUrlResponseRef, {
+    fields: (t) => ({
+        success: t.exposeBoolean('success'),
+        message: t.exposeString('message', { nullable: true }),
+        uploadUrls: t.field({
+            type: [UploadUrlInfoRef],
+            resolve: (parent) => parent.uploadUrls,
+        }),
+    }),
+});
 
 export const FileMutations = builder.mutationFields((t) => ({
     createFile: t.field({
@@ -65,6 +103,59 @@ export const FileMutations = builder.mutationFields((t) => ({
                 return {
                     success: false,
                     message: 'Error al eliminar el archivo',
+                };
+            }
+        },
+    }),
+
+    // Mutación para generar URLs presignadas
+    generateUploadUrls: t.field({
+        type: PresignedUrlResponseRef,
+        args: {
+            fileCount: t.arg.int({ required: true }),
+            prefix: t.arg.string({ required: true }),
+            mimeTypes: t.arg.stringList({ required: true }),
+        },
+        authz: {
+            rules: ['IsAuthenticated'],
+        },
+        resolve: async (_parent, { fileCount, prefix, mimeTypes }) => {
+            try {
+                if (fileCount <= 0 || fileCount > 10) {
+                    return {
+                        success: false,
+                        message: 'El número de archivos debe estar entre 1 y 10',
+                        uploadUrls: [],
+                    };
+                }
+
+                if (mimeTypes.length !== fileCount) {
+                    return {
+                        success: false,
+                        message:
+                            'La cantidad de tipos MIME debe coincidir con la cantidad de archivos',
+                        uploadUrls: [],
+                    };
+                }
+
+                const uploadUrls = await Promise.all(
+                    Array.from({ length: fileCount }).map(async (_, index) => {
+                        // Generar un nombre de archivo único
+                        const uniqueKey = `${prefix}/${Date.now()}-${Math.random().toString(36).substring(2, 15)}-${index + 1}`;
+                        return createUploadPresignedUrl(uniqueKey, mimeTypes[index]);
+                    }),
+                );
+
+                return {
+                    success: true,
+                    uploadUrls,
+                };
+            } catch (error) {
+                console.error('Error al generar URLs presignadas:', error);
+                return {
+                    success: false,
+                    message: 'Error al generar las URLs para subir archivos',
+                    uploadUrls: [],
                 };
             }
         },

--- a/cors-config.json
+++ b/cors-config.json
@@ -1,0 +1,18 @@
+{
+    "CORSRules": [
+        {
+            "AllowedHeaders": ["*"],
+            "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+            "AllowedOrigins": ["*"],
+            "ExposeHeaders": [
+                "ETag",
+                "x-amz-server-side-encryption",
+                "x-amz-request-id",
+                "x-amz-id-2",
+                "Content-Length",
+                "Content-Type"
+            ],
+            "MaxAgeSeconds": 3000
+        }
+    ]
+}

--- a/src/api/documents/expense.graphql
+++ b/src/api/documents/expense.graphql
@@ -119,8 +119,8 @@ mutation DeleteExpense($id: String!, $taskId: String!) {
 }
 
 mutation GenerateApprovedExpensesReport(
-    $startDate: String!
-    $endDate: String!
+    $startDate: DateTime!
+    $endDate: DateTime!
     $filters: JSON
 ) {
     generateApprovedExpensesReport(
@@ -161,5 +161,26 @@ mutation UpdateExpenseDiscountAmount($expenseId: String!, $discountAmount: Float
         }
         success
         message
+    }
+}
+
+mutation CreateExpense($taskId: String, $expenseData: ExpenseInput!) {
+    createExpense(taskId: $taskId, expenseData: $expenseData) {
+        success
+        message
+        expense {
+            id
+            amount
+            expenseType
+            paySource
+            paySourceBank
+            installments
+            expenseDate
+            doneBy
+            cityName
+            observations
+            expenseNumber
+            status
+        }
     }
 }

--- a/src/api/documents/expense.graphql
+++ b/src/api/documents/expense.graphql
@@ -40,24 +40,28 @@ query GetExpense($id: String!) {
 }
 
 query GetExpenses(
-    $registeredBy: [String!], 
-    $status: [ExpenseStatus!], 
-    $expenseType: [ExpenseType!],
-    $paySource: [ExpensePaySource!],
-    $expenseDateFrom: DateTime,
-    $expenseDateTo: DateTime,
-    $skip: Int,
+    $registeredBy: [String!]
+    $status: [ExpenseStatus!]
+    $expenseType: [ExpenseType!]
+    $paySource: [ExpensePaySource!]
+    $expenseDateFrom: DateTime
+    $expenseDateTo: DateTime
+    $skip: Int
     $take: Int
+    $orderBy: String
+    $orderDirection: String
 ) {
     expenses(
-        registeredBy: $registeredBy, 
-        status: $status, 
-        expenseType: $expenseType,
-        paySource: $paySource,
-        expenseDateFrom: $expenseDateFrom,
-        expenseDateTo: $expenseDateTo,
-        skip: $skip,
+        registeredBy: $registeredBy
+        status: $status
+        expenseType: $expenseType
+        paySource: $paySource
+        expenseDateFrom: $expenseDateFrom
+        expenseDateTo: $expenseDateTo
+        skip: $skip
         take: $take
+        orderBy: $orderBy
+        orderDirection: $orderDirection
     ) {
         id
         expenseNumber
@@ -95,18 +99,18 @@ query GetExpenses(
         status
     }
     expensesCount(
-        registeredBy: $registeredBy, 
-        status: $status, 
-        expenseType: $expenseType,
-        paySource: $paySource,
-        expenseDateFrom: $expenseDateFrom,
+        registeredBy: $registeredBy
+        status: $status
+        expenseType: $expenseType
+        paySource: $paySource
+        expenseDateFrom: $expenseDateFrom
         expenseDateTo: $expenseDateTo
     )
 }
 
-mutation DeleteExpense ($id: String!, $taskId: String!) {
-    deleteExpense (id: $id, taskId: $taskId) {
-        expense{
+mutation DeleteExpense($id: String!, $taskId: String!) {
+    deleteExpense(id: $id, taskId: $taskId) {
+        expense {
             id
         }
         success
@@ -114,10 +118,17 @@ mutation DeleteExpense ($id: String!, $taskId: String!) {
     }
 }
 
-mutation GenerateApprovedExpensesReport($startDate: DateTime!, $endDate: DateTime!, $filters: JSON) {
-    generateApprovedExpensesReport(startDate: $startDate, endDate: $endDate, filters: $filters)
+mutation GenerateApprovedExpensesReport(
+    $startDate: String!
+    $endDate: String!
+    $filters: JSON
+) {
+    generateApprovedExpensesReport(
+        startDate: $startDate
+        endDate: $endDate
+        filters: $filters
+    )
 }
-
 
 mutation UpdateExpenseStatus($expenseId: String!, $status: ExpenseStatus!) {
     updateExpenseStatus(expenseId: $expenseId, status: $status) {

--- a/src/api/documents/file.graphql
+++ b/src/api/documents/file.graphql
@@ -1,0 +1,11 @@
+mutation GenerateUploadUrls($fileCount: Int!, $prefix: String!, $mimeTypes: [String!]!) {
+    generateUploadUrls(fileCount: $fileCount, prefix: $prefix, mimeTypes: $mimeTypes) {
+        success
+        message
+        uploadUrls {
+            url
+            key
+            urlExpire
+        }
+    }
+}

--- a/src/api/graphql.schema.json
+++ b/src/api/graphql.schema.json
@@ -1,10 +1,12 @@
 {
     "__schema": {
         "queryType": {
-            "name": "Query"
+            "name": "Query",
+            "kind": "OBJECT"
         },
         "mutationType": {
-            "name": "Mutation"
+            "name": "Mutation",
+            "kind": "OBJECT"
         },
         "subscriptionType": null,
         "types": [
@@ -12,6 +14,7 @@
                 "kind": "OBJECT",
                 "name": "AuthResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "message",
@@ -63,6 +66,7 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "description": "The `Boolean` scalar type represents `true` or `false`.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -73,6 +77,7 @@
                 "kind": "OBJECT",
                 "name": "Branch",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "businesses",
@@ -172,6 +177,7 @@
                 "kind": "OBJECT",
                 "name": "BranchCrudResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "branch",
@@ -223,6 +229,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "BranchInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -306,6 +313,7 @@
                 "kind": "OBJECT",
                 "name": "Business",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "branchesIDs",
@@ -413,6 +421,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "BusinessInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -440,6 +449,7 @@
                 "kind": "OBJECT",
                 "name": "BusinessResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "business",
@@ -491,6 +501,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "ChangePasswordInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -534,6 +545,7 @@
                 "kind": "OBJECT",
                 "name": "City",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "id",
@@ -593,6 +605,7 @@
                 "kind": "OBJECT",
                 "name": "CityCrudRef",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "city",
@@ -644,6 +657,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "CityInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -687,6 +701,7 @@
                 "kind": "OBJECT",
                 "name": "Client",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "branches",
@@ -798,6 +813,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "ClientInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -825,6 +841,7 @@
                 "kind": "OBJECT",
                 "name": "ClientResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "client",
@@ -876,6 +893,7 @@
                 "kind": "SCALAR",
                 "name": "Date",
                 "description": "A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -886,6 +904,7 @@
                 "kind": "SCALAR",
                 "name": "DateTime",
                 "description": "A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -896,6 +915,7 @@
                 "kind": "OBJECT",
                 "name": "Expense",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "amount",
@@ -1195,6 +1215,7 @@
                 "kind": "OBJECT",
                 "name": "ExpenseCrudResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "expense",
@@ -1246,6 +1267,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "ExpenseInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -1489,6 +1511,7 @@
                 "kind": "ENUM",
                 "name": "ExpensePaySource",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -1530,6 +1553,7 @@
                 "kind": "ENUM",
                 "name": "ExpensePaySourceBank",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -1571,6 +1595,7 @@
                 "kind": "ENUM",
                 "name": "ExpenseStatus",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -1600,6 +1625,7 @@
                 "kind": "ENUM",
                 "name": "ExpenseType",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -1653,6 +1679,7 @@
                 "kind": "OBJECT",
                 "name": "ExpensesResponse",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "items",
@@ -1704,6 +1731,7 @@
                 "kind": "OBJECT",
                 "name": "File",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "createdAt",
@@ -1879,6 +1907,7 @@
                 "kind": "OBJECT",
                 "name": "FileCrudRef",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "file",
@@ -1930,6 +1959,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "FileInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -2021,6 +2051,7 @@
                 "kind": "SCALAR",
                 "name": "Float",
                 "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -2031,6 +2062,7 @@
                 "kind": "SCALAR",
                 "name": "ID",
                 "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -2041,6 +2073,7 @@
                 "kind": "OBJECT",
                 "name": "Image",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "id",
@@ -2112,6 +2145,7 @@
                 "kind": "SCALAR",
                 "name": "Int",
                 "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -2122,6 +2156,7 @@
                 "kind": "SCALAR",
                 "name": "JSON",
                 "description": "The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -2132,6 +2167,7 @@
                 "kind": "OBJECT",
                 "name": "LoginUserResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "accessToken",
@@ -2207,6 +2243,7 @@
                 "kind": "OBJECT",
                 "name": "Mutation",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "changePassword",
@@ -3167,6 +3204,79 @@
                         "deprecationReason": null
                     },
                     {
+                        "name": "generateUploadUrls",
+                        "description": null,
+                        "args": [
+                            {
+                                "name": "fileCount",
+                                "description": null,
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    }
+                                },
+                                "defaultValue": null,
+                                "isDeprecated": false,
+                                "deprecationReason": null
+                            },
+                            {
+                                "name": "mimeTypes",
+                                "description": null,
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "LIST",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "NON_NULL",
+                                            "name": null,
+                                            "ofType": {
+                                                "kind": "SCALAR",
+                                                "name": "String",
+                                                "ofType": null
+                                            }
+                                        }
+                                    }
+                                },
+                                "defaultValue": null,
+                                "isDeprecated": false,
+                                "deprecationReason": null
+                            },
+                            {
+                                "name": "prefix",
+                                "description": null,
+                                "type": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                },
+                                "defaultValue": null,
+                                "isDeprecated": false,
+                                "deprecationReason": null
+                            }
+                        ],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "PresignedUrlResponse",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
                         "name": "login",
                         "description": null,
                         "args": [
@@ -3842,6 +3952,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "MyTaskInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -4059,8 +4170,73 @@
             },
             {
                 "kind": "OBJECT",
+                "name": "PresignedUrlResponse",
+                "description": null,
+                "isOneOf": null,
+                "fields": [
+                    {
+                        "name": "message",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "success",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "uploadUrls",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "UploadUrlInfo",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "enumValues": null,
+                "possibleTypes": null
+            },
+            {
+                "kind": "OBJECT",
                 "name": "Preventive",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "assigned",
@@ -4260,6 +4436,7 @@
                 "kind": "OBJECT",
                 "name": "PreventiveCrudRef",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "message",
@@ -4311,6 +4488,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "PreventiveInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -4470,6 +4648,7 @@
                 "kind": "ENUM",
                 "name": "PreventiveStatus",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -4493,6 +4672,7 @@
                 "kind": "OBJECT",
                 "name": "Province",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "cities",
@@ -4592,6 +4772,7 @@
                 "kind": "OBJECT",
                 "name": "ProvinceCrudResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "message",
@@ -4643,6 +4824,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "ProvinceInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -4670,6 +4852,7 @@
                 "kind": "OBJECT",
                 "name": "Query",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "branch",
@@ -6844,6 +7027,7 @@
                 "kind": "ENUM",
                 "name": "Role",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -6879,6 +7063,7 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -6889,6 +7074,7 @@
                 "kind": "OBJECT",
                 "name": "Task",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "actNumber",
@@ -7308,6 +7494,7 @@
                 "kind": "OBJECT",
                 "name": "TaskCrudResult",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "message",
@@ -7359,6 +7546,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "TaskInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -7510,6 +7698,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "TaskReportFilterInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -7553,6 +7742,7 @@
                 "kind": "ENUM",
                 "name": "TaskStatus",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -7588,6 +7778,7 @@
                 "kind": "ENUM",
                 "name": "TaskType",
                 "description": null,
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -7635,6 +7826,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "UpdateMyTaskInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -7824,8 +8016,69 @@
             },
             {
                 "kind": "OBJECT",
+                "name": "UploadUrlInfo",
+                "description": null,
+                "isOneOf": null,
+                "fields": [
+                    {
+                        "name": "key",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "url",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "name": "urlExpire",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": null,
+                "interfaces": [],
+                "enumValues": null,
+                "possibleTypes": null
+            },
+            {
+                "kind": "OBJECT",
                 "name": "User",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "city",
@@ -7953,6 +8206,7 @@
                 "kind": "OBJECT",
                 "name": "UserCrudPothosRef",
                 "description": null,
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "message",
@@ -8004,6 +8258,7 @@
                 "kind": "INPUT_OBJECT",
                 "name": "UserInput",
                 "description": null,
+                "isOneOf": false,
                 "fields": null,
                 "inputFields": [
                     {
@@ -8103,6 +8358,7 @@
                 "kind": "OBJECT",
                 "name": "__Directive",
                 "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "name",
@@ -8219,6 +8475,7 @@
                 "kind": "ENUM",
                 "name": "__DirectiveLocation",
                 "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -8344,6 +8601,7 @@
                 "kind": "OBJECT",
                 "name": "__EnumValue",
                 "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "name",
@@ -8411,6 +8669,7 @@
                 "kind": "OBJECT",
                 "name": "__Field",
                 "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "name",
@@ -8531,6 +8790,7 @@
                 "kind": "OBJECT",
                 "name": "__InputValue",
                 "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "name",
@@ -8626,6 +8886,7 @@
                 "kind": "OBJECT",
                 "name": "__Schema",
                 "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "description",
@@ -8737,6 +8998,7 @@
                 "kind": "OBJECT",
                 "name": "__Type",
                 "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+                "isOneOf": null,
                 "fields": [
                     {
                         "name": "kind",
@@ -8940,6 +9202,18 @@
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
+                    },
+                    {
+                        "name": "isOneOf",
+                        "description": null,
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "Boolean",
+                            "ofType": null
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
                     }
                 ],
                 "inputFields": null,
@@ -8951,6 +9225,7 @@
                 "kind": "ENUM",
                 "name": "__TypeKind",
                 "description": "An enum describing what kind of type a given `__Type` is.",
+                "isOneOf": null,
                 "fields": null,
                 "inputFields": null,
                 "interfaces": null,
@@ -9056,6 +9331,13 @@
                         "deprecationReason": null
                     }
                 ]
+            },
+            {
+                "name": "oneOf",
+                "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
+                "isRepeatable": false,
+                "locations": ["INPUT_OBJECT"],
+                "args": []
             },
             {
                 "name": "skip",

--- a/src/api/graphql.schema.json
+++ b/src/api/graphql.schema.json
@@ -5434,6 +5434,30 @@
                                 "deprecationReason": null
                             },
                             {
+                                "name": "orderBy",
+                                "description": null,
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                },
+                                "defaultValue": null,
+                                "isDeprecated": false,
+                                "deprecationReason": null
+                            },
+                            {
+                                "name": "orderDirection",
+                                "description": null,
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                },
+                                "defaultValue": null,
+                                "isDeprecated": false,
+                                "deprecationReason": null
+                            },
+                            {
                                 "name": "paySource",
                                 "description": null,
                                 "type": {

--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -280,6 +280,7 @@ export type Mutation = {
     finishTask: TaskCrudResult;
     generateApprovedExpensesReport: Scalars['String'];
     generateApprovedTasksReport: Scalars['String'];
+    generateUploadUrls: PresignedUrlResponse;
     login: LoginUserResult;
     logout: AuthResult;
     sendNewUserRandomPassword: UserCrudPothosRef;
@@ -408,6 +409,12 @@ export type MutationGenerateApprovedTasksReportArgs = {
     startDate: InputMaybe<Scalars['DateTime']>;
 };
 
+export type MutationGenerateUploadUrlsArgs = {
+    fileCount: Scalars['Int'];
+    mimeTypes: Array<Scalars['String']>;
+    prefix: Scalars['String'];
+};
+
 export type MutationLoginArgs = {
     email: Scalars['String'];
     password: Scalars['String'];
@@ -491,6 +498,13 @@ export type MyTaskInput = {
     startedAt: InputMaybe<Scalars['DateTime']>;
     taskType: TaskType;
     useMaterials: Scalars['Boolean'];
+};
+
+export type PresignedUrlResponse = {
+    __typename?: 'PresignedUrlResponse';
+    message: Maybe<Scalars['String']>;
+    success: Scalars['Boolean'];
+    uploadUrls: Array<UploadUrlInfo>;
 };
 
 export type Preventive = {
@@ -869,6 +883,13 @@ export type UpdateMyTaskInput = {
     participants: InputMaybe<Array<Scalars['String']>>;
     startedAt: InputMaybe<Scalars['DateTime']>;
     useMaterials: Scalars['Boolean'];
+};
+
+export type UploadUrlInfo = {
+    __typename?: 'UploadUrlInfo';
+    key: Scalars['String'];
+    url: Scalars['String'];
+    urlExpire: Scalars['String'];
 };
 
 export type User = {
@@ -1433,6 +1454,56 @@ export type UpdateExpenseDiscountAmountMutation = {
             amount: number;
             discountAmount: number | null;
         } | null;
+    };
+};
+
+export type CreateExpenseMutationVariables = Exact<{
+    taskId: InputMaybe<Scalars['String']>;
+    expenseData: ExpenseInput;
+}>;
+
+export type CreateExpenseMutation = {
+    __typename?: 'Mutation';
+    createExpense: {
+        __typename?: 'ExpenseCrudResult';
+        success: boolean;
+        message: string | null;
+        expense: {
+            __typename?: 'Expense';
+            id: string;
+            amount: number;
+            expenseType: ExpenseType;
+            paySource: ExpensePaySource;
+            paySourceBank: ExpensePaySourceBank | null;
+            installments: number | null;
+            expenseDate: any | null;
+            doneBy: string;
+            cityName: string | null;
+            observations: string | null;
+            expenseNumber: string;
+            status: ExpenseStatus;
+        } | null;
+    };
+};
+
+export type GenerateUploadUrlsMutationVariables = Exact<{
+    fileCount: Scalars['Int'];
+    prefix: Scalars['String'];
+    mimeTypes: Array<Scalars['String']>;
+}>;
+
+export type GenerateUploadUrlsMutation = {
+    __typename?: 'Mutation';
+    generateUploadUrls: {
+        __typename?: 'PresignedUrlResponse';
+        success: boolean;
+        message: string | null;
+        uploadUrls: Array<{
+            __typename?: 'UploadUrlInfo';
+            url: string;
+            key: string;
+            urlExpire: string;
+        }>;
     };
 };
 
@@ -5201,6 +5272,290 @@ export const UpdateExpenseDiscountAmountDocument = {
 } as unknown as DocumentNode<
     UpdateExpenseDiscountAmountMutation,
     UpdateExpenseDiscountAmountMutationVariables
+>;
+export const CreateExpenseDocument = {
+    kind: 'Document',
+    definitions: [
+        {
+            kind: 'OperationDefinition',
+            operation: 'mutation',
+            name: { kind: 'Name', value: 'CreateExpense' },
+            variableDefinitions: [
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'taskId' },
+                    },
+                    type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+                },
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'expenseData' },
+                    },
+                    type: {
+                        kind: 'NonNullType',
+                        type: {
+                            kind: 'NamedType',
+                            name: { kind: 'Name', value: 'ExpenseInput' },
+                        },
+                    },
+                },
+            ],
+            selectionSet: {
+                kind: 'SelectionSet',
+                selections: [
+                    {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'createExpense' },
+                        arguments: [
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'taskId' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'taskId' },
+                                },
+                            },
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'expenseData' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'expenseData' },
+                                },
+                            },
+                        ],
+                        selectionSet: {
+                            kind: 'SelectionSet',
+                            selections: [
+                                {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'success' },
+                                },
+                                {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'message' },
+                                },
+                                {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'expense' },
+                                    selectionSet: {
+                                        kind: 'SelectionSet',
+                                        selections: [
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'id' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'amount' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'expenseType',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'paySource',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'paySourceBank',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'installments',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'expenseDate',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'doneBy' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'cityName' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'observations',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'expenseNumber',
+                                                },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'status' },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+} as unknown as DocumentNode<CreateExpenseMutation, CreateExpenseMutationVariables>;
+export const GenerateUploadUrlsDocument = {
+    kind: 'Document',
+    definitions: [
+        {
+            kind: 'OperationDefinition',
+            operation: 'mutation',
+            name: { kind: 'Name', value: 'GenerateUploadUrls' },
+            variableDefinitions: [
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'fileCount' },
+                    },
+                    type: {
+                        kind: 'NonNullType',
+                        type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+                    },
+                },
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'prefix' },
+                    },
+                    type: {
+                        kind: 'NonNullType',
+                        type: {
+                            kind: 'NamedType',
+                            name: { kind: 'Name', value: 'String' },
+                        },
+                    },
+                },
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'mimeTypes' },
+                    },
+                    type: {
+                        kind: 'NonNullType',
+                        type: {
+                            kind: 'ListType',
+                            type: {
+                                kind: 'NonNullType',
+                                type: {
+                                    kind: 'NamedType',
+                                    name: { kind: 'Name', value: 'String' },
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+            selectionSet: {
+                kind: 'SelectionSet',
+                selections: [
+                    {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'generateUploadUrls' },
+                        arguments: [
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'fileCount' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'fileCount' },
+                                },
+                            },
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'prefix' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'prefix' },
+                                },
+                            },
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'mimeTypes' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'mimeTypes' },
+                                },
+                            },
+                        ],
+                        selectionSet: {
+                            kind: 'SelectionSet',
+                            selections: [
+                                {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'success' },
+                                },
+                                {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'message' },
+                                },
+                                {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'uploadUrls' },
+                                    selectionSet: {
+                                        kind: 'SelectionSet',
+                                        selections: [
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'url' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'key' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: {
+                                                    kind: 'Name',
+                                                    value: 'urlExpire',
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+} as unknown as DocumentNode<
+    GenerateUploadUrlsMutation,
+    GenerateUploadUrlsMutationVariables
 >;
 export const GetPreventivesDocument = {
     kind: 'Document',

--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -670,6 +670,8 @@ export type QueryExpensesArgs = {
     expenseDateFrom: InputMaybe<Scalars['DateTime']>;
     expenseDateTo: InputMaybe<Scalars['DateTime']>;
     expenseType: InputMaybe<Array<ExpenseType>>;
+    orderBy: InputMaybe<Scalars['String']>;
+    orderDirection: InputMaybe<Scalars['String']>;
     paySource: InputMaybe<Array<ExpensePaySource>>;
     registeredBy: InputMaybe<Array<Scalars['String']>>;
     skip: InputMaybe<Scalars['Int']>;
@@ -1317,6 +1319,8 @@ export type GetExpensesQueryVariables = Exact<{
     expenseDateTo: InputMaybe<Scalars['DateTime']>;
     skip: InputMaybe<Scalars['Int']>;
     take: InputMaybe<Scalars['Int']>;
+    orderBy: InputMaybe<Scalars['String']>;
+    orderDirection: InputMaybe<Scalars['String']>;
 }>;
 
 export type GetExpensesQuery = {
@@ -4415,6 +4419,22 @@ export const GetExpensesDocument = {
                     variable: { kind: 'Variable', name: { kind: 'Name', value: 'take' } },
                     type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
                 },
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'orderBy' },
+                    },
+                    type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+                },
+                {
+                    kind: 'VariableDefinition',
+                    variable: {
+                        kind: 'Variable',
+                        name: { kind: 'Name', value: 'orderDirection' },
+                    },
+                    type: { kind: 'NamedType', name: { kind: 'Name', value: 'String' } },
+                },
             ],
             selectionSet: {
                 kind: 'SelectionSet',
@@ -4485,6 +4505,22 @@ export const GetExpensesDocument = {
                                 value: {
                                     kind: 'Variable',
                                     name: { kind: 'Name', value: 'take' },
+                                },
+                            },
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'orderBy' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'orderBy' },
+                                },
+                            },
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'orderDirection' },
+                                value: {
+                                    kind: 'Variable',
+                                    name: { kind: 'Name', value: 'orderDirection' },
                                 },
                             },
                         ],

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -37,7 +37,7 @@ const Combobox = (props: Props) => {
             return (
                 <p className="flex w-full justify-between space-x-1">
                     <span>{option.label}</span>
-                    {isSelected && <Check className="h-4 w-4" />}
+                    {isSelected && <Check className="size-4" />}
                 </p>
             );
         }
@@ -46,7 +46,7 @@ const Combobox = (props: Props) => {
             <div className="flex flex-col items-start space-y-1">
                 <p className="flex w-full justify-between space-x-1">
                     <span>{option.label}</span>
-                    {isSelected && <Check className="h-4 w-4" />}
+                    {isSelected && <Check className="size-4" />}
                 </p>
                 <p className="text-sm text-muted-foreground">{item.description}</p>
             </div>
@@ -64,7 +64,7 @@ const Combobox = (props: Props) => {
                         className="min-w-[200px] justify-between"
                     >
                         {label || selectPlaceholder}
-                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                        <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
                     </Button>
                 </PopoverTrigger>
 

--- a/src/components/DashboardLayout/NavBar/index.tsx
+++ b/src/components/DashboardLayout/NavBar/index.tsx
@@ -58,7 +58,7 @@ function UserMenu({ user }: NavBarProps) {
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="flex items-center gap-2">
-                    <User className="h-4 w-4" />
+                    <User className="size-4" />
                     <span className="text-sm">{user.email}</span>
                 </Button>
             </DropdownMenuTrigger>
@@ -69,7 +69,7 @@ function UserMenu({ user }: NavBarProps) {
                 <DropdownMenuGroup>
                     <DropdownMenuItem asChild>
                         <Link href="/edit-profile" className="flex w-full cursor-pointer">
-                            <User className="mr-2 h-4 w-4" />
+                            <User className="mr-2 size-4" />
                             <span>Perfil</span>
                         </Link>
                     </DropdownMenuItem>
@@ -81,7 +81,7 @@ function UserMenu({ user }: NavBarProps) {
                         variant="ghost"
                         disabled={logoutMutation.isPending}
                     >
-                        <LogOut className="mr-2 h-4 w-4" />
+                        <LogOut className="mr-2 size-4" />
                         <span>Cerrar sesión</span>
                     </Button>
                 </DropdownMenuItem>

--- a/src/components/Forms/Accounting/CreateExpenseForm.tsx
+++ b/src/components/Forms/Accounting/CreateExpenseForm.tsx
@@ -1,0 +1,1109 @@
+import Image from 'next/image';
+// import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { CalendarIcon, Download, Eye, PlusCircle, X } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import {
+    Expense,
+    ExpensePaySource,
+    ExpensePaySourceBank,
+    ExpenseType,
+    GetTechniciansQuery,
+} from '@/api/graphql';
+import Combobox from '@/components/Combobox';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Textarea } from '@/components/ui/textarea';
+import { TypographyH2 } from '@/components/ui/typography';
+import { toast } from '@/components/ui/use-toast';
+import { useCreateExpense } from '@/hooks/api/expense/useCreateExpense';
+import { useGenerateUploadUrls } from '@/hooks/api/file/useGenerateUploadUrls';
+import { routesBuilder } from '@/lib/routes';
+import { cn } from '@/lib/utils';
+
+// Definición de las opciones para ciudades
+const CITY_OPTIONS = [
+    {
+        label: 'Trelew',
+        value: 'Trelew',
+    },
+    {
+        label: 'Rawson',
+        value: 'Rawson',
+    },
+    {
+        label: 'Madryn',
+        value: 'Madryn',
+    },
+    {
+        label: 'Comodoro',
+        value: 'Comodoro',
+    },
+    {
+        label: 'Esquel',
+        value: 'Esquel',
+    },
+    {
+        label: 'Otro',
+        value: 'Otro',
+    },
+];
+
+interface CreateExpenseFormProps {
+    taskId?: string;
+    techs: NonNullable<GetTechniciansQuery['technicians']>;
+}
+
+interface ExpenseFormValues {
+    amount: number;
+    expenseType: ExpenseType;
+    paySource: ExpensePaySource;
+    paySourceBank?: ExpensePaySourceBank;
+    installments?: number;
+    expenseDate: Date;
+    doneBy: string;
+    customDoneBy?: string;
+    cityName: string;
+    customCityName?: string;
+    observations?: string;
+    fileKeys: string[];
+    filenames: string[];
+    mimeTypes: string[];
+    sizes: number[];
+}
+
+// Función para formatear número como moneda argentina (punto para miles, coma para decimales)
+const formatCurrency = (value: string): string => {
+    if (!value) {
+        return '';
+    }
+
+    // Eliminar puntos y reemplazar coma por punto para convertir a número
+    const numericValue = value.replace(/\./g, '').replace(',', '.');
+
+    // Convertir a número y limitar a 2 decimales
+    const number = parseFloat(numericValue);
+    if (isNaN(number)) {
+        return '';
+    }
+
+    // Formatear con separador de miles y decimales
+    const parts = number.toFixed(2).split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+
+    // Devolver con coma como separador decimal
+    return parts.join(',');
+};
+
+// Función para convertir valor con formato de moneda argentina a número decimal
+const currencyToNumber = (value: string): number => {
+    if (!value) {
+        return 0;
+    }
+    // Eliminar puntos y reemplazar coma por punto para convertir a número
+    return parseFloat(value.replace(/\./g, '').replace(',', '.')) || 0;
+};
+
+// Función para formatear fechas
+const formatDate = (date: Date | string | null | undefined): string => {
+    if (!date) {
+        return 'N/A';
+    }
+    return format(new Date(date), 'dd/MM/yyyy', { locale: es });
+};
+
+export default function CreateExpenseForm({ taskId, techs }: CreateExpenseFormProps) {
+    const router = useRouter();
+    const createExpenseMutation = useCreateExpense();
+    const generateUploadUrlsMutation = useGenerateUploadUrls();
+    const [files, setFiles] = useState<File[]>([]);
+    const [uploadedFiles, setUploadedFiles] = useState<
+        {
+            key: string;
+            filename: string;
+            mimeType: string;
+            size: number;
+        }[]
+    >([]);
+
+    const form = useForm<ExpenseFormValues>({
+        defaultValues: {
+            amount: 0,
+            installments: 1,
+            expenseDate: new Date(),
+            fileKeys: [],
+            filenames: [],
+            mimeTypes: [],
+            sizes: [],
+        },
+    });
+
+    // Estado local para manejar los valores de los campos numéricos como string
+    const [amountInputValue, setAmountInputValue] = useState('0');
+    const [installmentsInputValue, setInstallmentsInputValue] = useState('1');
+
+    const watchPaySource = form.watch('paySource');
+    const watchDoneBy = form.watch('doneBy');
+    const watchCityName = form.watch('cityName');
+
+    // Función para manejar la subida de archivos
+    const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (!event.target.files || event.target.files.length === 0) {
+            return;
+        }
+
+        // Verificar que no se exceda el límite de 5 archivos
+        if (files.length + event.target.files.length > 5) {
+            toast({
+                description: 'No se pueden adjuntar más de 5 archivos en total',
+                variant: 'destructive',
+                duration: 5000,
+            });
+            return;
+        }
+
+        try {
+            // Guardar referencia a los archivos seleccionados
+            const newFiles = Array.from(event.target.files);
+
+            // Mostrar toast de carga
+            toast({
+                description: 'Preparando archivos...',
+                duration: 3000,
+            });
+
+            // Generar prefijo único para los archivos
+            const prefix = taskId ? `expenses/${taskId}` : 'expenses/no-task';
+
+            // Obtener URLs presignadas para subida
+            const result = await generateUploadUrlsMutation.mutateAsync({
+                fileCount: newFiles.length,
+                prefix,
+                mimeTypes: newFiles.map((file) => file.type),
+            });
+
+            if (!result.generateUploadUrls.success) {
+                console.log(result.generateUploadUrls.message);
+                throw new Error(
+                    result.generateUploadUrls.message ||
+                        'Error al generar URLs para subida',
+                );
+            }
+
+            // Mostrar toast de carga para la subida
+            toast({
+                description: 'Subiendo archivos...',
+                duration: 5000,
+            });
+
+            // Subir los archivos mediante nuestro endpoint de proxy
+            const uploadPromises = newFiles.map(async (file, index) => {
+                const { key } = result.generateUploadUrls.uploadUrls[index];
+
+                // Convertir archivo a Base64
+                const reader = new FileReader();
+                const fileBase64Promise = new Promise<string>((resolve) => {
+                    reader.onload = () => resolve(reader.result as string);
+                    reader.readAsDataURL(file);
+                });
+
+                const fileBase64 = await fileBase64Promise;
+
+                // Enviar al endpoint de proxy
+                const uploadResponse = await fetch('/api/upload-file', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        file: fileBase64,
+                        contentType: file.type,
+                        key: key,
+                    }),
+                });
+
+                if (!uploadResponse.ok) {
+                    const errorData = await uploadResponse.json();
+                    throw new Error(
+                        `Error al subir el archivo ${file.name}: ${errorData.error || uploadResponse.statusText}`,
+                    );
+                }
+
+                return {
+                    key,
+                    filename: file.name,
+                    mimeType: file.type,
+                    size: file.size,
+                };
+            });
+
+            // Esperar a que todas las subidas se completen
+            const fileInfo = await Promise.all(uploadPromises);
+
+            // Actualizar UI
+            setFiles([...files, ...newFiles]);
+
+            // Actualizar el formulario con las claves de los archivos
+            form.setValue('fileKeys', [
+                ...form.getValues('fileKeys'),
+                ...fileInfo.map((f) => f.key),
+            ]);
+            form.setValue('filenames', [
+                ...form.getValues('filenames'),
+                ...fileInfo.map((f) => f.filename),
+            ]);
+            form.setValue('mimeTypes', [
+                ...form.getValues('mimeTypes'),
+                ...fileInfo.map((f) => f.mimeType),
+            ]);
+            form.setValue('sizes', [
+                ...form.getValues('sizes'),
+                ...fileInfo.map((f) => f.size),
+            ]);
+
+            // También guardar la información para uso posterior
+            setUploadedFiles([...uploadedFiles, ...fileInfo]);
+
+            // Notificar éxito
+            toast({
+                description: `${newFiles.length} ${newFiles.length === 1 ? 'archivo subido' : 'archivos subidos'} exitosamente.`,
+                variant: 'success',
+                duration: 3000,
+            });
+        } catch (error) {
+            console.error('Error al subir archivos:', error);
+            toast({
+                description: `Error al subir los archivos: ${error instanceof Error ? error.message : 'Error desconocido'}`,
+                variant: 'destructive',
+                duration: 5000,
+            });
+        }
+    };
+
+    const removeFile = (index: number) => {
+        const newFiles = [...files];
+        newFiles.splice(index, 1);
+        setFiles(newFiles);
+
+        const newUploadedFiles = [...uploadedFiles];
+        newUploadedFiles.splice(index, 1);
+        setUploadedFiles(newUploadedFiles);
+
+        // Actualizamos los valores del formulario
+        form.setValue(
+            'fileKeys',
+            form.getValues('fileKeys').filter((_, i) => i !== index),
+        );
+        form.setValue(
+            'filenames',
+            form.getValues('filenames').filter((_, i) => i !== index),
+        );
+        form.setValue(
+            'mimeTypes',
+            form.getValues('mimeTypes').filter((_, i) => i !== index),
+        );
+        form.setValue(
+            'sizes',
+            form.getValues('sizes').filter((_, i) => i !== index),
+        );
+    };
+
+    const onSubmit = async (values: ExpenseFormValues) => {
+        try {
+            // Determinar el valor final de doneBy
+            const finalDoneBy =
+                values.doneBy === 'Otro'
+                    ? values.customDoneBy || 'Otro'
+                    : techs.find((tech) => tech.id === values.doneBy)?.fullName ||
+                      values.doneBy;
+
+            // Determinar el valor final de cityName
+            const finalCityName =
+                values.cityName === 'Otro'
+                    ? values.customCityName || 'Otro'
+                    : values.cityName;
+
+            // Si no hay archivos seleccionados, mostrar error
+            if (files.length === 0) {
+                toast({
+                    title: 'Error',
+                    description: 'Debe adjuntar al menos un archivo',
+                    variant: 'destructive',
+                    duration: 5000,
+                });
+                return;
+            }
+
+            // Mostrar toast de carga para archivos
+            toast({
+                description: 'Subiendo archivos...',
+                duration: 5000,
+            });
+
+            try {
+                // Generar prefijo para los archivos temporales - usaremos un timestamp
+                const timestamp = new Date().getTime();
+                // Usar el taskId si está disponible, o un prefijo temporal
+                const prefix = taskId
+                    ? `expenses/${taskId}/temp_${timestamp}`
+                    : `expenses/no-task/temp_${timestamp}`;
+
+                // Obtener URLs presignadas para subida
+                const urlsResult = await generateUploadUrlsMutation.mutateAsync({
+                    fileCount: files.length,
+                    prefix,
+                    mimeTypes: files.map((file) => file.type),
+                });
+
+                if (!urlsResult.generateUploadUrls.success) {
+                    throw new Error(
+                        urlsResult.generateUploadUrls.message ||
+                            'Error al generar URLs para subida de archivos',
+                    );
+                }
+
+                // Subir los archivos a S3 usando nuestro endpoint de proxy
+                const uploadPromises = files.map(async (file, index) => {
+                    const { key } = urlsResult.generateUploadUrls.uploadUrls[index];
+
+                    // Convertir archivo a Base64
+                    const reader = new FileReader();
+                    const fileBase64Promise = new Promise<string>((resolve) => {
+                        reader.onload = () => resolve(reader.result as string);
+                        reader.readAsDataURL(file);
+                    });
+
+                    const fileBase64 = await fileBase64Promise;
+
+                    // Enviar al endpoint de proxy
+                    const uploadResponse = await fetch('/api/upload-file', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            file: fileBase64,
+                            contentType: file.type,
+                            key: key,
+                        }),
+                    });
+
+                    if (!uploadResponse.ok) {
+                        const errorData = await uploadResponse.json();
+                        throw new Error(
+                            `Error al subir el archivo ${file.name}: ${errorData.error || uploadResponse.statusText}`,
+                        );
+                    }
+
+                    return {
+                        key,
+                        filename: file.name,
+                        mimeType: file.type,
+                        size: file.size,
+                    };
+                });
+
+                // Esperar a que todas las subidas se completen
+                const fileInfo = await Promise.all(uploadPromises);
+
+                // Mostrar toast de carga para la creación del gasto
+                toast({
+                    description: 'Creando gasto...',
+                    duration: 3000,
+                });
+
+                // Ahora creamos el gasto con las claves de archivos ya subidos
+                const result = await createExpenseMutation.mutateAsync({
+                    taskId,
+                    expenseData: {
+                        amount: values.amount,
+                        expenseType: values.expenseType,
+                        paySource: values.paySource,
+                        paySourceBank:
+                            values.paySource === ExpensePaySource.Credito ||
+                            values.paySource === ExpensePaySource.Debito
+                                ? values.paySourceBank || null
+                                : null,
+                        installments: values.installments || 1,
+                        expenseDate: values.expenseDate,
+                        doneBy: finalDoneBy,
+                        cityName: finalCityName,
+                        observations: values.observations || null,
+                        // Enviamos los arrays con la información de los archivos ya subidos
+                        fileKeys: fileInfo.map((f) => f.key),
+                        filenames: fileInfo.map((f) => f.filename),
+                        mimeTypes: fileInfo.map((f) => f.mimeType),
+                        sizes: fileInfo.map((f) => f.size),
+                        imageKeys: [], // No tenemos imágenes específicas, todo va como archivo
+                    },
+                });
+
+                if (
+                    !result?.createExpense?.success ||
+                    !result.createExpense.expense?.id
+                ) {
+                    throw new Error(
+                        result?.createExpense?.message || 'Error al crear el gasto',
+                    );
+                }
+
+                // Mostrar toast de éxito
+                toast({
+                    title: '¡Gasto creado exitosamente!',
+                    description: `El gasto #${result.createExpense.expense?.expenseNumber} ha sido registrado correctamente con ${fileInfo.length} archivos adjuntos.`,
+                    variant: 'success',
+                    duration: 5000,
+                });
+
+                // Redirigir después de un breve delay para que el usuario vea el mensaje
+                setTimeout(() => {
+                    if (taskId) {
+                        router.push(routesBuilder.tasks.details(taskId));
+                    } else {
+                        router.push(routesBuilder.accounting.expenses.list());
+                    }
+                }, 1000);
+            } catch (error) {
+                console.error('Error al procesar la solicitud:', error);
+
+                // Mostrar toast de error
+                toast({
+                    title: 'Error inesperado',
+                    description:
+                        error instanceof Error
+                            ? error.message
+                            : 'Ocurrió un error al procesar su solicitud. Por favor intente nuevamente.',
+                    variant: 'destructive',
+                    duration: 5000,
+                });
+            }
+        } catch (error) {
+            // Error en la validación o preparación de datos
+            console.error('Error al preparar datos:', error);
+
+            // Mostrar toast de error
+            toast({
+                title: 'Error de validación',
+                description:
+                    error instanceof Error
+                        ? error.message
+                        : 'Ocurrió un error al validar los datos. Por favor revise el formulario e intente nuevamente.',
+                variant: 'destructive',
+                duration: 5000,
+            });
+        }
+    };
+
+    return (
+        <main className="rounded-md border border-accent bg-background-primary p-4">
+            <TypographyH2 asChild className="mb-4">
+                <h1>Crear Gasto</h1>
+            </TypographyH2>
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                        {/* Monto */}
+                        <FormField
+                            name="amount"
+                            control={form.control}
+                            rules={{
+                                required: 'Este campo es requerido',
+                                min: {
+                                    value: 1,
+                                    message: 'El monto debe ser mayor a 0',
+                                },
+                            }}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Monto</FormLabel>
+                                    <FormControl>
+                                        <div className="relative">
+                                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                                                $
+                                            </span>
+                                            <Input
+                                                type="text"
+                                                placeholder="0"
+                                                value={amountInputValue}
+                                                className="pl-7"
+                                                onChange={(e) => {
+                                                    const value = e.target.value;
+                                                    // Permitir solo números, puntos y una única coma
+                                                    if (
+                                                        /^$|^[0-9.]*,?[0-9]*$/.test(value)
+                                                    ) {
+                                                        setAmountInputValue(value);
+                                                        // Convertir valor con formato a número para el formulario
+                                                        field.onChange(
+                                                            currencyToNumber(value),
+                                                        );
+                                                    }
+                                                }}
+                                                onFocus={(e) => e.target.select()}
+                                                onBlur={() => {
+                                                    // Si el campo está vacío al perder el foco, mostrar 0
+                                                    if (amountInputValue === '') {
+                                                        setAmountInputValue('0');
+                                                        field.onChange(0);
+                                                    } else {
+                                                        // Formatear el valor como moneda al perder el foco
+                                                        const formattedValue =
+                                                            formatCurrency(
+                                                                amountInputValue,
+                                                            );
+                                                        setAmountInputValue(
+                                                            formattedValue,
+                                                        );
+                                                        field.onChange(
+                                                            currencyToNumber(
+                                                                formattedValue,
+                                                            ),
+                                                        );
+                                                    }
+                                                }}
+                                            />
+                                        </div>
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {/* Tipo de gasto */}
+                        <FormField
+                            name="expenseType"
+                            control={form.control}
+                            rules={{
+                                required: 'Este campo es requerido',
+                            }}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Tipo de gasto</FormLabel>
+                                    <FormControl>
+                                        <Combobox
+                                            selectPlaceholder="Seleccione un tipo"
+                                            searchPlaceholder="Buscar tipo de gasto"
+                                            value={field.value || ''}
+                                            onChange={field.onChange}
+                                            items={Object.values(ExpenseType).map(
+                                                (type) => ({
+                                                    label: type,
+                                                    value: type,
+                                                }),
+                                            )}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {/* Fuente de pago */}
+                        <FormField
+                            name="paySource"
+                            control={form.control}
+                            rules={{
+                                required: 'Este campo es requerido',
+                            }}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Fuente de pago</FormLabel>
+                                    <FormControl>
+                                        <Combobox
+                                            selectPlaceholder="Seleccione una fuente"
+                                            searchPlaceholder="Buscar fuente de pago"
+                                            value={field.value || ''}
+                                            onChange={field.onChange}
+                                            items={Object.values(ExpensePaySource).map(
+                                                (source) => ({
+                                                    label: source,
+                                                    value: source,
+                                                }),
+                                            )}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {/* Banco emisor (condicional) */}
+                        {(watchPaySource === ExpensePaySource.Credito ||
+                            watchPaySource === ExpensePaySource.Debito) && (
+                            <FormField
+                                name="paySourceBank"
+                                control={form.control}
+                                rules={{
+                                    required: 'Este campo es requerido',
+                                }}
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Banco emisor</FormLabel>
+                                        <FormControl>
+                                            <Combobox
+                                                selectPlaceholder="Seleccione un banco"
+                                                searchPlaceholder="Buscar banco"
+                                                value={field.value || ''}
+                                                onChange={field.onChange}
+                                                items={Object.values(
+                                                    ExpensePaySourceBank,
+                                                ).map((bank) => ({
+                                                    label: bank,
+                                                    value: bank,
+                                                }))}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        )}
+
+                        {/* Cuotas (condicional) */}
+                        {watchPaySource === ExpensePaySource.Credito && (
+                            <FormField
+                                name="installments"
+                                control={form.control}
+                                rules={{
+                                    required: 'Este campo es requerido',
+                                    min: {
+                                        value: 1,
+                                        message: 'Las cuotas deben ser al menos 1',
+                                    },
+                                }}
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Cuotas</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                type="number"
+                                                placeholder="1"
+                                                value={installmentsInputValue}
+                                                onChange={(e) => {
+                                                    const value = e.target.value;
+                                                    if (/^$|^[0-9]*$/.test(value)) {
+                                                        setInstallmentsInputValue(value);
+                                                        field.onChange(
+                                                            value === ''
+                                                                ? 1
+                                                                : Number(value),
+                                                        );
+                                                    }
+                                                }}
+                                                onFocus={(e) => e.target.select()}
+                                                onBlur={() => {
+                                                    // Si el campo está vacío o es menor que 1 al perder el foco, mostrar 1
+                                                    if (
+                                                        installmentsInputValue === '' ||
+                                                        Number(installmentsInputValue) < 1
+                                                    ) {
+                                                        setInstallmentsInputValue('1');
+                                                        field.onChange(1);
+                                                    }
+                                                }}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        )}
+
+                        {/* Fecha de pago */}
+                        <FormField
+                            name="expenseDate"
+                            control={form.control}
+                            rules={{
+                                required: 'Este campo es requerido',
+                            }}
+                            render={({ field }) => (
+                                <FormItem className="flex flex-col">
+                                    <FormLabel>Fecha de pago</FormLabel>
+                                    <Popover>
+                                        <PopoverTrigger asChild>
+                                            <FormControl>
+                                                <Button
+                                                    variant="outline"
+                                                    className={cn(
+                                                        'w-full pl-3 text-left font-normal',
+                                                        !field.value &&
+                                                            'text-muted-foreground',
+                                                    )}
+                                                >
+                                                    {field.value ? (
+                                                        format(
+                                                            field.value,
+                                                            'dd/MM/yyyy',
+                                                            { locale: es },
+                                                        )
+                                                    ) : (
+                                                        <span>Seleccione una fecha</span>
+                                                    )}
+                                                    <CalendarIcon className="ml-auto size-4 opacity-50" />
+                                                </Button>
+                                            </FormControl>
+                                        </PopoverTrigger>
+                                        <PopoverContent
+                                            className="w-auto p-0"
+                                            align="start"
+                                        >
+                                            <Calendar
+                                                mode="single"
+                                                selected={field.value}
+                                                onSelect={field.onChange}
+                                                disabled={(date) => date > new Date()}
+                                                initialFocus
+                                            />
+                                        </PopoverContent>
+                                    </Popover>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {/* Pagado por */}
+                        <FormField
+                            name="doneBy"
+                            control={form.control}
+                            rules={{
+                                required: 'Este campo es requerido',
+                            }}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Pagado por</FormLabel>
+                                    <FormControl>
+                                        <Combobox
+                                            selectPlaceholder="Seleccione quién pagó"
+                                            searchPlaceholder="Buscar"
+                                            value={field.value || ''}
+                                            onChange={field.onChange}
+                                            items={[
+                                                ...techs.map((tech) => ({
+                                                    label: tech.fullName,
+                                                    value: tech.id,
+                                                })),
+                                                {
+                                                    label: 'Otro',
+                                                    value: 'Otro',
+                                                },
+                                            ]}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {/* Campo personalizado para "Pagado por" */}
+                        {watchDoneBy === 'Otro' && (
+                            <FormField
+                                name="customDoneBy"
+                                control={form.control}
+                                rules={{
+                                    required: 'Este campo es requerido',
+                                }}
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Nombre de quien pagó</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                placeholder="Ingrese el nombre"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        )}
+
+                        {/* Ciudad */}
+                        <FormField
+                            name="cityName"
+                            control={form.control}
+                            rules={{
+                                required: 'Este campo es requerido',
+                            }}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Ciudad</FormLabel>
+                                    <FormControl>
+                                        <Combobox
+                                            selectPlaceholder="Seleccione una ciudad"
+                                            searchPlaceholder="Buscar ciudad"
+                                            value={field.value || ''}
+                                            onChange={field.onChange}
+                                            items={CITY_OPTIONS}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {/* Campo personalizado para "Ciudad" */}
+                        {watchCityName === 'Otro' && (
+                            <FormField
+                                name="customCityName"
+                                control={form.control}
+                                rules={{
+                                    required: 'Este campo es requerido',
+                                }}
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>Nombre de la ciudad</FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                placeholder="Ingrese el nombre de la ciudad"
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        )}
+                    </div>
+
+                    {/* Observaciones */}
+                    <FormField
+                        name="observations"
+                        control={form.control}
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Observaciones</FormLabel>
+                                <FormControl>
+                                    <Textarea
+                                        placeholder="Ingrese observaciones (opcional)"
+                                        {...field}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    {/* Archivos */}
+                    <div className="space-y-2">
+                        <FormLabel>Archivos (máximo 5)</FormLabel>
+                        <div className="flex flex-wrap gap-2">
+                            {files.map((file, index) => (
+                                <div
+                                    key={index}
+                                    className="flex items-center rounded-md border border-accent bg-background p-2"
+                                >
+                                    <span className="mr-2 max-w-32 truncate">
+                                        {file.name}
+                                    </span>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        onClick={() => removeFile(index)}
+                                    >
+                                        <X className="size-4" />
+                                    </Button>
+                                </div>
+                            ))}
+                            {files.length < 5 && (
+                                <label className="flex cursor-pointer items-center rounded-md border border-dashed border-accent bg-background p-2 hover:bg-accent/10">
+                                    <PlusCircle className="mr-2 size-4" />
+                                    <span>Añadir imagen</span>
+                                    <input
+                                        type="file"
+                                        className="hidden"
+                                        onChange={handleFileUpload}
+                                        accept="image/*"
+                                    />
+                                </label>
+                            )}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                            Se requiere al menos una imagen. Formatos aceptados: JPG, PNG,
+                            GIF, etc.
+                        </p>
+                    </div>
+
+                    <div className="flex justify-end space-x-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => {
+                                if (taskId) {
+                                    router.push(routesBuilder.tasks.details(taskId));
+                                } else {
+                                    router.push(routesBuilder.accounting.expenses.list());
+                                }
+                            }}
+                        >
+                            Cancelar
+                        </Button>
+                        <Button
+                            type="submit"
+                            disabled={
+                                createExpenseMutation.isPending || files.length === 0
+                            }
+                        >
+                            {createExpenseMutation.isPending
+                                ? 'Creando...'
+                                : 'Crear Gasto'}
+                        </Button>
+                    </div>
+                </form>
+            </Form>
+        </main>
+    );
+}
+
+type ExpenseDetailProps = {
+    expense: Expense;
+    taskId?: string;
+};
+
+export const ExpenseDetail = ({ expense, taskId }: ExpenseDetailProps) => {
+    const router = useRouter();
+
+    // Combinar imágenes y archivos en una sola lista
+    const files = [
+        ...(expense.images || []).map((image) => ({
+            url: image.url,
+            key: image.key,
+            filename: `Imagen ${image.id.substring(0, 6)}`,
+            mimeType: 'image/jpeg',
+            id: image.id,
+        })),
+        ...(expense.files || []).map((file) => ({
+            url: file.url,
+            key: file.key,
+            filename: file.filename || `Imagen`,
+            mimeType: file.mimeType || 'image/jpeg',
+            id: file.id,
+        })),
+    ];
+
+    return (
+        <Card className="overflow-hidden">
+            <CardHeader className="bg-muted/30">
+                <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">
+                        Gasto #{expense.expenseNumber} -{' '}
+                        {formatCurrency(String(expense.amount || 0))}
+                    </CardTitle>
+                    {taskId && (
+                        <Button variant="outline" size="sm" onClick={() => router.back()}>
+                            Volver a la tarea
+                        </Button>
+                    )}
+                </div>
+            </CardHeader>
+            <CardContent className="p-4">
+                <div className="mb-6 grid grid-cols-2 gap-4 md:grid-cols-4">
+                    <div>
+                        <h4 className="text-sm font-semibold text-muted-foreground">
+                            Tipo:
+                        </h4>
+                        <p>{expense.expenseType}</p>
+                    </div>
+                    <div>
+                        <h4 className="text-sm font-semibold text-muted-foreground">
+                            Forma de pago:
+                        </h4>
+                        <p>{expense.paySource}</p>
+                    </div>
+                    <div>
+                        <h4 className="text-sm font-semibold text-muted-foreground">
+                            Ciudad:
+                        </h4>
+                        <p>{expense.cityName}</p>
+                    </div>
+                    <div>
+                        <h4 className="text-sm font-semibold text-muted-foreground">
+                            Pagado por:
+                        </h4>
+                        <p>{expense.doneBy}</p>
+                    </div>
+                    <div>
+                        <h4 className="text-sm font-semibold text-muted-foreground">
+                            Fecha:
+                        </h4>
+                        <p>{formatDate(expense.expenseDate)}</p>
+                    </div>
+                    <div>
+                        <h4 className="text-sm font-semibold text-muted-foreground">
+                            Estado:
+                        </h4>
+                        <p>{expense.status}</p>
+                    </div>
+                    {expense.observations && (
+                        <div className="col-span-2 md:col-span-4">
+                            <h4 className="text-sm font-semibold text-muted-foreground">
+                                Observaciones:
+                            </h4>
+                            <p className="whitespace-pre-line">{expense.observations}</p>
+                        </div>
+                    )}
+                </div>
+
+                {files.length > 0 && (
+                    <div>
+                        <h4 className="mb-2 text-sm font-semibold text-muted-foreground">
+                            Imágenes adjuntas:
+                        </h4>
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                            {files.map((file, index) => (
+                                <div key={index} className="group">
+                                    <div className="relative aspect-square overflow-hidden rounded-md border border-accent">
+                                        <Image
+                                            src={file.url}
+                                            alt={file.filename}
+                                            fill
+                                            className="object-contain transition-all duration-300 group-hover:scale-105"
+                                        />
+                                        <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-300 group-hover:bg-black/60 group-hover:opacity-100">
+                                            <div className="flex gap-2">
+                                                <a
+                                                    href={file.url}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="rounded-full bg-white p-2 text-black transition-transform hover:scale-110"
+                                                >
+                                                    <Eye size={16} />
+                                                </a>
+                                                <a
+                                                    href={file.url}
+                                                    download={file.filename}
+                                                    className="rounded-full bg-white p-2 text-black transition-transform hover:scale-110"
+                                                >
+                                                    <Download size={16} />
+                                                </a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <p className="mt-1 text-center text-xs text-muted-foreground">
+                                        {file.filename}
+                                    </p>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+};

--- a/src/components/Forms/TechAdmin/CreateOrUpdatePreventiveForm.tsx
+++ b/src/components/Forms/TechAdmin/CreateOrUpdatePreventiveForm.tsx
@@ -468,7 +468,7 @@ const CreateOrUpdatePreventiveForm = ({
                                                 ) : (
                                                     <span>Seleccione una fecha</span>
                                                 )}
-                                                <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                                                <CalendarIcon className="ml-auto size-4 opacity-50" />
                                             </Button>
                                         </FormControl>
                                     </PopoverTrigger>
@@ -511,7 +511,7 @@ const CreateOrUpdatePreventiveForm = ({
                                                 ) : (
                                                     <span>Seleccione una fecha</span>
                                                 )}
-                                                <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                                                <CalendarIcon className="ml-auto size-4 opacity-50" />
                                             </Button>
                                         </FormControl>
                                     </PopoverTrigger>

--- a/src/components/Forms/TechAdmin/CreateOrUpdateTaskForm.tsx
+++ b/src/components/Forms/TechAdmin/CreateOrUpdateTaskForm.tsx
@@ -103,7 +103,7 @@ const CreateOrUpdateTaskForm: React.FC<Props> = ({
                 setValue('business', 'Otro');
             }
         }
-    }, [taskIdToUpdate]);
+    }, [taskIdToUpdate, defaultValues, setValue]);
 
     const watchedBusiness = watch('business');
     const watchedBranch = watch('branch');
@@ -160,7 +160,7 @@ const CreateOrUpdateTaskForm: React.FC<Props> = ({
                 input: {
                     auditor: null,
                     branch: form.branch ?? null,
-                    business: form.business === 'Otro' ? null : form.business ?? null,
+                    business: form.business === 'Otro' ? null : (form.business ?? null),
                     clientName: form.clientName ?? null,
                     businessName: form.businessName ?? null,
                     description: form.description,
@@ -225,7 +225,7 @@ const CreateOrUpdateTaskForm: React.FC<Props> = ({
                 input: {
                     auditor: null,
                     branch: form.branch ?? null,
-                    business: form.business === 'Otro' ? null : form.business ?? null,
+                    business: form.business === 'Otro' ? null : (form.business ?? null),
                     clientName: form.clientName ?? null,
                     businessName: form.businessName ?? null,
                     description: form.description,

--- a/src/components/Modals/ExpenseReportModal.tsx
+++ b/src/components/Modals/ExpenseReportModal.tsx
@@ -56,7 +56,7 @@ export function ExpenseReportModal({ isOpen, onClose, filters }: Props) {
                                         variant="outline"
                                         className="justify-start text-left font-normal"
                                     >
-                                        <CalendarIcon className="mr-2 h-4 w-4" />
+                                        <CalendarIcon className="mr-2 size-4" />
                                         {startDate ? (
                                             format(startDate, 'PP', { locale: es })
                                         ) : (
@@ -89,7 +89,7 @@ export function ExpenseReportModal({ isOpen, onClose, filters }: Props) {
                                         variant="outline"
                                         className="justify-start text-left font-normal"
                                     >
-                                        <CalendarIcon className="mr-2 h-4 w-4" />
+                                        <CalendarIcon className="mr-2 size-4" />
                                         {endDate ? (
                                             format(endDate, 'PP', { locale: es })
                                         ) : (

--- a/src/components/Modals/TaskReportModal.tsx
+++ b/src/components/Modals/TaskReportModal.tsx
@@ -56,7 +56,7 @@ export function TaskReportModal({ isOpen, onClose, filters }: Props) {
                                         variant="outline"
                                         className="justify-start text-left font-normal"
                                     >
-                                        <CalendarIcon className="mr-2 h-4 w-4" />
+                                        <CalendarIcon className="mr-2 size-4" />
                                         {startDate ? (
                                             format(startDate, 'PP', { locale: es })
                                         ) : (
@@ -89,7 +89,7 @@ export function TaskReportModal({ isOpen, onClose, filters }: Props) {
                                         variant="outline"
                                         className="justify-start text-left font-normal"
                                     >
-                                        <CalendarIcon className="mr-2 h-4 w-4" />
+                                        <CalendarIcon className="mr-2 size-4" />
                                         {endDate ? (
                                             format(endDate, 'PP', { locale: es })
                                         ) : (

--- a/src/components/MultiSelect.tsx
+++ b/src/components/MultiSelect.tsx
@@ -84,7 +84,7 @@ export function FancyMultiSelect({
                                     }}
                                     onClick={() => handleUnselect(option)}
                                 >
-                                    <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                                    <X className="size-3 text-muted-foreground hover:text-foreground" />
                                 </button>
                             </Badge>
                         );

--- a/src/components/ui/data-table/index.tsx
+++ b/src/components/ui/data-table/index.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import { DataTablePagination } from './data-table-pagination';
 import { DataTableToolbar, ToolbarConfig } from './data-table-toolbar';
 import { TypographyH1 } from '../typography';
-import { CustomScrollArea } from "../custom-scroll-area/index";
+import { CustomScrollArea } from '../custom-scroll-area/index';
 
 interface DataTableProps<TData> {
     table: TanstackTable<TData>;
@@ -39,30 +39,28 @@ export function DataTable<TData>({
     const dynamicHeight = useMemo(() => {
         const rows = table.getRowModel().rows;
         const actualRowCount = Math.min(rows.length, totalCount); // Usar el número real de filas
-        
+
         if (actualRowCount === 0) return 'h-[145px]';
-        
+
         const ROW_HEIGHT = 53; // Altura ajustada por fila
         const HEADER_HEIGHT = 45;
         const MIN_HEIGHT = 200;
         const MAX_HEIGHT = 470;
-        
-        const contentHeight = (actualRowCount * ROW_HEIGHT) + HEADER_HEIGHT;
+
+        const contentHeight = actualRowCount * ROW_HEIGHT + HEADER_HEIGHT;
         const height = `h-[${Math.max(Math.min(contentHeight, MAX_HEIGHT), MIN_HEIGHT)}px] max-h-[470px]`;
         console.log(height);
         return height;
     }, [table.getRowModel().rows.length, totalCount]);
 
     return (
-        <div className='flex flex-col gap-1'>
-            <div className="rounded-lg border border-accent bg-background-primary pb-2 pt-4 px-4 flex flex-col gap-1">
+        <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1 rounded-lg border border-accent bg-background-primary px-4 pb-2 pt-4">
                 {/* Header */}
-                    <div className="flex justify-between">
-                        <TypographyH1>{title}</TypographyH1>
-                        {headerActions && (
-                            <div className="flex gap-2">{headerActions}</div>
-                        )}
-                    </div>
+                <div className="flex justify-between">
+                    <TypographyH1>{title}</TypographyH1>
+                    {headerActions && <div className="flex gap-2">{headerActions}</div>}
+                </div>
 
                 {/* Toolbar */}
                 {toolbarConfig && (
@@ -71,30 +69,35 @@ export function DataTable<TData>({
 
                 {/* Pagination */}
 
-                    <DataTablePagination
-                        totalCount={totalCount}
-                        page={page}
-                        pageSize={pageSize}
-                        onPageChange={onPageChange}
-                        onPageSizeChange={onPageSizeChange}
-                    />
-
+                <DataTablePagination
+                    totalCount={totalCount}
+                    page={page}
+                    pageSize={pageSize}
+                    onPageChange={onPageChange}
+                    onPageSizeChange={onPageSizeChange}
+                />
             </div>
             {/* Table con scroll en el body */}
 
             <CustomScrollArea height={dynamicHeight}>
                 <Table>
-                    <TableHeader className="sticky top-0 z-10 bg-primary hover:bg-primary border-accent">
+                    <TableHeader className="sticky top-0 z-10 border-accent bg-primary text-start hover:bg-primary">
                         {table.getHeaderGroups().map((headerGroup) => (
-                            <TableRow key={headerGroup.id} className="border-accent hover:bg-primary">
+                            <TableRow
+                                key={headerGroup.id}
+                                className="border-accent hover:bg-primary"
+                            >
                                 {headerGroup.headers.map((header) => (
-                                    <TableHead key={header.id} className="text-primary-foreground">
+                                    <TableHead
+                                        key={header.id}
+                                        className="text-primary-foreground"
+                                    >
                                         {header.isPlaceholder
                                             ? null
                                             : flexRender(
-                                                    header.column.columnDef.header,
-                                                    header.getContext(),
-                                                )}
+                                                  header.column.columnDef.header,
+                                                  header.getContext(),
+                                              )}
                                     </TableHead>
                                 ))}
                             </TableRow>
@@ -107,7 +110,7 @@ export function DataTable<TData>({
                                     key={row.id}
                                     data-state={row.getIsSelected() && 'selected'}
                                     onClick={() => onRowClick?.(row.original)}
-                                    className={`${onRowClick ? 'cursor-pointer' : ''} bg-background-primary hover:bg-accent border-b border-accent`}
+                                    className={`${onRowClick ? 'cursor-pointer' : ''} border-b border-accent bg-background-primary hover:bg-accent`}
                                 >
                                     {row.getVisibleCells().map((cell) => (
                                         <TableCell key={cell.id}>
@@ -123,7 +126,7 @@ export function DataTable<TData>({
                             <TableRow>
                                 <TableCell
                                     colSpan={table.getAllColumns().length}
-                                    className="h-24 text-center bg-background-primary"
+                                    className="h-24 bg-background-primary text-center"
                                 >
                                     No se encontraron resultados.
                                 </TableCell>
@@ -134,4 +137,4 @@ export function DataTable<TData>({
             </CustomScrollArea>
         </div>
     );
-} 
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -68,7 +68,7 @@ const TableHead = React.forwardRef<
     <th
         ref={ref}
         className={cn(
-            'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+            'h-12 text-nowrap px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
             className,
         )}
         {...props}
@@ -82,7 +82,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
     <td
         ref={ref}
-        className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0', className)}
+        className={cn(
+            'px-4 py-2 text-left align-middle [&:has([role=checkbox])]:pr-0',
+            className,
+        )}
         {...props}
     />
 ));

--- a/src/hooks/api/expense/useCreateExpense.ts
+++ b/src/hooks/api/expense/useCreateExpense.ts
@@ -1,0 +1,105 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { ExpenseInput } from '@/api/graphql';
+
+// Definimos manualmente los tipos para la mutación ya que no están generados automáticamente
+type CreateExpenseMutation = {
+    createExpense: {
+        success: boolean;
+        message?: string;
+        expense?: {
+            id: string;
+            amount: number;
+            expenseType: string;
+            paySource: string;
+            paySourceBank?: string | null;
+            installments?: number | null;
+            expenseDate: string;
+            doneBy: string;
+            cityName: string;
+            observations?: string | null;
+            expenseNumber: string;
+            status: string;
+        };
+    };
+};
+
+type CreateExpenseMutationVariables = {
+    taskId?: string;
+    expenseData: ExpenseInput;
+};
+
+export const useCreateExpense = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<CreateExpenseMutation, Error, CreateExpenseMutationVariables>({
+        mutationFn: async (variables) => {
+            const url =
+                typeof window !== 'undefined'
+                    ? `${window.location.origin}/api/graphql`
+                    : '/api/graphql';
+
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                },
+                credentials: 'include',
+                body: JSON.stringify({
+                    query: `
+                      mutation CreateExpense($taskId: String, $expenseData: ExpenseInput!) {
+                        createExpense(taskId: $taskId, expenseData: $expenseData) {
+                          success
+                          message
+                          expense {
+                            id
+                            amount
+                            expenseType
+                            paySource
+                            paySourceBank
+                            installments
+                            expenseDate
+                            doneBy
+                            cityName
+                            observations
+                            expenseNumber
+                            status
+                          }
+                        }
+                      }
+                    `,
+                    variables,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Error de red: ${response.status}`);
+            }
+
+            const json = await response.json();
+
+            if (json.errors && json.errors.length > 0) {
+                const firstError = json.errors[0];
+                let message = firstError.message;
+
+                const firstErrorSplitted = firstError.message.split('Error: ');
+                if (firstErrorSplitted.length > 1) {
+                    message = firstErrorSplitted.slice(1).join('');
+                }
+
+                throw new Error(message);
+            }
+
+            return json.data as CreateExpenseMutation;
+        },
+        onSuccess: () => {
+            // Invalidar consultas relacionadas con gastos
+            queryClient.invalidateQueries({ queryKey: ['expenses'] });
+            queryClient.invalidateQueries({ queryKey: ['expense'] });
+            // También invalidar consultas de tareas si se está relacionando un gasto
+            queryClient.invalidateQueries({ queryKey: ['tasks'] });
+            queryClient.invalidateQueries({ queryKey: ['task'] });
+        },
+    });
+};

--- a/src/hooks/api/file/useGenerateUploadUrls.ts
+++ b/src/hooks/api/file/useGenerateUploadUrls.ts
@@ -1,0 +1,111 @@
+import { useMutation } from '@tanstack/react-query';
+import { gql } from 'graphql-tag';
+
+// Definimos manualmente los tipos para la mutación
+type GenerateUploadUrlsMutation = {
+    generateUploadUrls: {
+        success: boolean;
+        message?: string;
+        uploadUrls: {
+            url: string;
+            key: string;
+            urlExpire: string;
+        }[];
+    };
+};
+
+type GenerateUploadUrlsMutationVariables = {
+    fileCount: number;
+    prefix: string;
+    mimeTypes: string[];
+};
+
+// Definimos la mutación usando graphql-tag para asegurar un AST válido
+const GENERATE_UPLOAD_URLS = gql`
+    mutation GenerateUploadUrls(
+        $fileCount: Int!
+        $prefix: String!
+        $mimeTypes: [String!]!
+    ) {
+        generateUploadUrls(
+            fileCount: $fileCount
+            prefix: $prefix
+            mimeTypes: $mimeTypes
+        ) {
+            success
+            message
+            uploadUrls {
+                url
+                key
+                urlExpire
+            }
+        }
+    }
+`;
+
+export const useGenerateUploadUrls = () => {
+    return useMutation<
+        GenerateUploadUrlsMutation,
+        Error,
+        GenerateUploadUrlsMutationVariables
+    >({
+        mutationFn: async (variables) => {
+            try {
+                const url =
+                    typeof window !== 'undefined'
+                        ? `${window.location.origin}/api/graphql`
+                        : '/api/graphql';
+
+                console.log('Enviando solicitud para generar URLs presignadas:', {
+                    fileCount: variables.fileCount,
+                    prefix: variables.prefix,
+                    mimeTypesCount: variables.mimeTypes.length,
+                });
+
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json',
+                    },
+                    credentials: 'include',
+                    body: JSON.stringify({
+                        query: GENERATE_UPLOAD_URLS.loc?.source.body,
+                        variables,
+                    }),
+                });
+
+                if (!response.ok) {
+                    console.error('Error de red:', response.status, response.statusText);
+                    throw new Error(`Error de red: ${response.status}`);
+                }
+
+                const json = await response.json();
+                console.log('Respuesta recibida:', json);
+
+                if (json.errors && json.errors.length > 0) {
+                    const firstError = json.errors[0];
+                    console.error('Error GraphQL:', firstError);
+                    let message = firstError.message;
+
+                    const firstErrorSplitted = firstError.message.split('Error: ');
+                    if (firstErrorSplitted.length > 1) {
+                        message = firstErrorSplitted.slice(1).join('');
+                    }
+
+                    throw new Error(message);
+                }
+
+                if (!json.data || !json.data.generateUploadUrls) {
+                    console.error('Respuesta inesperada sin datos:', json);
+                    throw new Error('Respuesta inesperada del servidor');
+                }
+
+                return json.data as GenerateUploadUrlsMutation;
+            } catch (error) {
+                console.error('Error completo en useGenerateUploadUrls:', error);
+                throw error;
+            }
+        },
+    });
+};

--- a/src/hooks/api/task/useGetTask.ts
+++ b/src/hooks/api/task/useGetTask.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchClient } from '@/api/fetch-client';
+import { GetTaskDocument, GetTaskQuery, GetTaskQueryVariables } from '@/api/graphql';
+
+export const useGetTask = (variables: GetTaskQueryVariables) => {
+    return useQuery<GetTaskQuery>({
+        queryKey: ['task', variables.id],
+        queryFn: () => fetchClient(GetTaskDocument, variables),
+        enabled: !!variables.id,
+    });
+};

--- a/src/hooks/useAlert.ts
+++ b/src/hooks/useAlert.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export type AlertType = 'Success' | 'Failure' | 'Warning' | 'Info';
+
+interface Alert {
+    type: AlertType;
+    message: string;
+}
+
+export function useAlert() {
+    const [alert, setAlert] = useState<Alert | null>(null);
+
+    const triggerAlert = (alert: Alert) => {
+        setAlert(alert);
+
+        // Auto-dismiss alert after 3 seconds
+        setTimeout(() => {
+            setAlert(null);
+        }, 3000);
+    };
+
+    return {
+        alert,
+        triggerAlert,
+    };
+}

--- a/src/modules/ExpenseDetail/index.tsx
+++ b/src/modules/ExpenseDetail/index.tsx
@@ -2,8 +2,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { DownloadIcon } from '@radix-ui/react-icons';
 import dayjs from 'dayjs';
+import { Eye } from 'lucide-react';
 import { useState } from 'react';
 
 import { GetExpenseQuery, ExpenseStatus } from '@/api/graphql';
@@ -195,27 +195,31 @@ const Content: React.FC<Props> = ({ expense }) => {
                     {expense.images && expense.images.length > 0 && (
                         <div>
                             <Title>Imágenes</Title>
-                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+                            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
                                 {expense.images.map((image) => (
-                                    <a
-                                        key={image.id}
-                                        className="group relative block overflow-hidden rounded-md border border-accent"
-                                        download={image.id}
-                                        href={image.url}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                    >
-                                        <Image
-                                            src={image.url}
-                                            width={500}
-                                            height={700}
-                                            alt=""
-                                            className="aspect-[5/7] w-full object-cover"
-                                        />
-                                        <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/30 opacity-0 transition-colors duration-200 group-hover:bg-background/90 group-hover:opacity-100">
-                                            <DownloadIcon className="h-6 w-6" />
+                                    <div key={image.id} className="group">
+                                        <div className="relative aspect-square overflow-hidden rounded-md border border-accent">
+                                            <Image
+                                                src={image.url}
+                                                alt=""
+                                                fill
+                                                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                                                className="object-contain transition-all duration-300"
+                                            />
+                                            <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-300 group-hover:bg-black/60 group-hover:opacity-100">
+                                                <div className="flex gap-2">
+                                                    <a
+                                                        href={image.url}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="rounded-full bg-white p-3 text-black transition-transform hover:scale-110"
+                                                    >
+                                                        <Eye className="size-5" />
+                                                    </a>
+                                                </div>
+                                            </div>
                                         </div>
-                                    </a>
+                                    </div>
                                 ))}
                             </div>
                         </div>
@@ -227,11 +231,35 @@ const Content: React.FC<Props> = ({ expense }) => {
                             <div className="grid gap-4 sm:grid-cols-2">
                                 {expense.files.map((file) => (
                                     <div key={file.id}>
-                                        {file.mimeType.startsWith('application/pdf') ? (
+                                        {file.mimeType &&
+                                        file.mimeType.startsWith('image/') ? (
+                                            <div className="group relative aspect-square overflow-hidden rounded-md border border-accent">
+                                                <Image
+                                                    src={file.url}
+                                                    alt={file.filename || ''}
+                                                    fill
+                                                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                                                    className="object-contain transition-all duration-300"
+                                                />
+                                                <div className="absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-all duration-300 group-hover:bg-black/60 group-hover:opacity-100">
+                                                    <div className="flex gap-2">
+                                                        <a
+                                                            href={file.url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            className="rounded-full bg-white p-3 text-black transition-transform hover:scale-110"
+                                                        >
+                                                            <Eye className="size-5" />
+                                                        </a>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ) : file.mimeType &&
+                                          file.mimeType.startsWith('application/pdf') ? (
                                             <div className="h-[600px] w-full">
                                                 <PDFViewer
                                                     url={file.url}
-                                                    filename={file.filename}
+                                                    filename={file.filename || ''}
                                                     showPreviewButton={false}
                                                 />
                                             </div>
@@ -247,8 +275,9 @@ const Content: React.FC<Props> = ({ expense }) => {
                                                     target="_blank"
                                                     rel="noreferrer"
                                                 >
-                                                    <DownloadIcon />
-                                                    {file.filename}
+                                                    <Eye className="mr-2 size-4" />
+                                                    {file.filename ||
+                                                        `Archivo ${file.id.substring(0, 6)}`}
                                                 </a>
                                             </Button>
                                         )}

--- a/src/modules/Forms/Accounting/CreateBillingForm/InvoiceSection.tsx
+++ b/src/modules/Forms/Accounting/CreateBillingForm/InvoiceSection.tsx
@@ -162,7 +162,7 @@ export const InvoiceSection = () => {
                                                 ) : (
                                                     <span>Seleccione fecha</span>
                                                 )}
-                                                <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                                                <CalendarIcon className="ml-auto size-4 opacity-50" />
                                             </Button>
                                         </FormControl>
                                     </PopoverTrigger>
@@ -207,7 +207,7 @@ export const InvoiceSection = () => {
                                                     ) : (
                                                         <span>Seleccione fecha</span>
                                                     )}
-                                                    <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                                                    <CalendarIcon className="ml-auto size-4 opacity-50" />
                                                 </Button>
                                             </FormControl>
                                         </PopoverTrigger>
@@ -255,7 +255,7 @@ export const InvoiceSection = () => {
                                                 ) : (
                                                     <span>Seleccione fecha</span>
                                                 )}
-                                                <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                                                <CalendarIcon className="ml-auto size-4 opacity-50" />
                                             </Button>
                                         </FormControl>
                                     </PopoverTrigger>

--- a/src/modules/ServiceOrderDetail/index.tsx
+++ b/src/modules/ServiceOrderDetail/index.tsx
@@ -144,7 +144,7 @@ const Content = ({ serviceOrder = mockServiceOrder }) => {
             cell: (task) => (
                 <div className="flex -space-x-2">
                     {task.assigned.map((tech) => (
-                        <Avatar key={tech.id} className="h-8 w-8">
+                        <Avatar key={tech.id} className="size-8">
                             <AvatarFallback className="text-xs">
                                 {tech.fullName[0].toUpperCase()}
                             </AvatarFallback>

--- a/src/modules/TaskDetail/columns.tsx
+++ b/src/modules/TaskDetail/columns.tsx
@@ -67,7 +67,7 @@ export const expenseColumns: Column<Expense>[] = [
                     {expense.images.map((image) => (
                         <a
                             key={image.id}
-                            className="h-15 group relative inline-block w-20 overflow-hidden rounded-md border border-accent"
+                            className="group relative inline-block h-14 w-20 overflow-hidden rounded-md border border-accent"
                             download={image.id}
                             href={image.url}
                             target="_blank"
@@ -78,10 +78,10 @@ export const expenseColumns: Column<Expense>[] = [
                                 width={40}
                                 height={40}
                                 alt=""
-                                className="h-full w-full object-cover"
+                                className="size-full object-cover"
                             />
                             <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/30 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
-                                <DownloadIcon className="h-4 w-4" />
+                                <DownloadIcon className="size-4" />
                             </div>
                         </a>
                     ))}
@@ -111,7 +111,7 @@ export const expenseColumns: Column<Expense>[] = [
                                     target="_blank"
                                     rel="noreferrer"
                                 >
-                                    <DownloadIcon className="mr-2 h-4 w-4" />
+                                    <DownloadIcon className="mr-2 size-4" />
                                     {file.filename}
                                 </a>
                             </Button>

--- a/src/modules/TaskDetail/index.tsx
+++ b/src/modules/TaskDetail/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 
 import { DownloadIcon } from '@radix-ui/react-icons';
 import { format } from 'date-fns';
+import { BsPlus } from 'react-icons/bs';
 
 import { expenseColumns } from './columns';
 
@@ -184,37 +185,44 @@ const Content: React.FC<Props> = ({ task }) => {
                         </div>
                     )}
                 </section>
-                {user.roles.includes('AdministrativoContable') && (
-                    <section>
-                        {task.expenses.length === 0 ? (
-                            <>
-                                <Title>Gastos</Title>
-                                <p className="text-muted-foreground">No hay gastos</p>
-                            </>
-                        ) : (
-                            <>
-                                <Title>
-                                    Gastos: $
-                                    {task.expenses
-                                        .reduce((acc, curr) => acc + curr.amount, 0)
-                                        .toLocaleString('es-AR')}
-                                </Title>
-                                <DataList
-                                    data={task.expenses}
-                                    columns={expenseColumns}
-                                    onRowClick={(expense) =>
-                                        router.push(
-                                            routesBuilder.accounting.expenses.details(
-                                                expense.id,
-                                            ),
-                                        )
-                                    }
-                                    emptyMessage="No hay gastos"
-                                />
-                            </>
+                <section className="flex flex-col gap-2">
+                    <div className="flex flex-col items-start justify-between">
+                        <Title>
+                            {task.expenses.length === 0
+                                ? 'Gastos'
+                                : `Gastos: $${task.expenses
+                                      .reduce((acc, curr) => acc + curr.amount, 0)
+                                      .toLocaleString('es-AR')}`}
+                        </Title>
+                        {(user.roles.includes('AdministrativoContable') ||
+                            user.roles.includes('AdministrativoTecnico')) && (
+                            <Button
+                                className="flex items-center gap-1"
+                                onClick={() =>
+                                    router.push(`/tasks/${task.id}/expenses/create`)
+                                }
+                            >
+                                <BsPlus size="20" />
+                                <span>Crear nuevo gasto</span>
+                            </Button>
                         )}
-                    </section>
-                )}
+                    </div>
+
+                    {task.expenses.length === 0 ? (
+                        <p className="text-muted-foreground">No hay gastos</p>
+                    ) : (
+                        <DataList
+                            data={task.expenses}
+                            columns={expenseColumns}
+                            onRowClick={(expense) =>
+                                router.push(
+                                    routesBuilder.accounting.expenses.details(expense.id),
+                                )
+                            }
+                            emptyMessage="No hay gastos"
+                        />
+                    )}
+                </section>
             </div>
         </main>
     );

--- a/src/modules/tables/BillingDataTable/billing-table-row-actions.tsx
+++ b/src/modules/tables/BillingDataTable/billing-table-row-actions.tsx
@@ -34,10 +34,10 @@ export function BillingTableRowActions({ bill }: Props) {
                 <DropdownMenuTrigger asChild>
                     <Button
                         variant="ghost"
-                        className="flex h-8 w-8 p-0"
+                        className="flex size-8 p-0"
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/BillingProfilesTable/billing-profiles-table-row-actions.tsx
+++ b/src/modules/tables/BillingProfilesTable/billing-profiles-table-row-actions.tsx
@@ -32,8 +32,8 @@ export function BillingProfilesTableRowActions({ profile }: Props) {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/BudgetsTable/budgets-table-row-actions.tsx
+++ b/src/modules/tables/BudgetsTable/budgets-table-row-actions.tsx
@@ -33,8 +33,8 @@ export function BudgetsTableRowActions({ budget }: Props) {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/BusinessesDataTable/businesses-table-row-actions.tsx
+++ b/src/modules/tables/BusinessesDataTable/businesses-table-row-actions.tsx
@@ -52,8 +52,8 @@ export function BusinessesTableRowActions({ business }: Props) {
         <div className="flex w-full justify-end">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/CitiesDataTable/cities-table-row-actions.tsx
+++ b/src/modules/tables/CitiesDataTable/cities-table-row-actions.tsx
@@ -52,8 +52,8 @@ export function CitiesTableRowActions({ city }: Props) {
         <div className="flex w-full justify-end">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/ClientBranchesTable/client-branches-table-row-actions.tsx
+++ b/src/modules/tables/ClientBranchesTable/client-branches-table-row-actions.tsx
@@ -69,8 +69,8 @@ export function RowActions({ branch, client }: Props): JSX.Element {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/ClientsDataTable/clients-table-row-actions.tsx
+++ b/src/modules/tables/ClientsDataTable/clients-table-row-actions.tsx
@@ -52,8 +52,8 @@ export function ClientsTableRowActions({ client }: Props) {
         <div className="flex w-full justify-end">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/ClientsDataTable/index.tsx
+++ b/src/modules/tables/ClientsDataTable/index.tsx
@@ -30,11 +30,11 @@ export function ClientsDataTable() {
     useEffect(() => {
         setPage(0);
         refetch();
-    }, [searchTerm, pageSize]);
+    }, [searchTerm, pageSize, refetch]);
 
     useEffect(() => {
         refetch();
-    }, [page, pageSize]);
+    }, [page, pageSize, refetch]);
 
     const handleSearch = (term: string) => {
         setSearchTerm(term);

--- a/src/modules/tables/ExpensesDataTable/columns.tsx
+++ b/src/modules/tables/ExpensesDataTable/columns.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { ExpenseStatus, ExpenseType } from '@prisma/client';
 import { createColumnHelper } from '@tanstack/react-table';
 import { format } from 'date-fns';
+import { ArrowDown, ArrowUp } from 'lucide-react';
 
 import { ExpensesTableRowActions } from './expenses-table-row-actions';
 
@@ -19,11 +20,30 @@ const columnHelper = createColumnHelper<Expense>();
 export const useExpensesTableColumns = () => [
     columnHelper.accessor((row) => row.expenseNumber, {
         id: 'expenseNumber',
-        header: 'Número',
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span>Número</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
+        },
         cell: (info) => {
             const expenseNumber = info.getValue();
-            return <span className="font-medium">#{expenseNumber}</span>;
+            return <span className="block text-left font-medium">#{expenseNumber}</span>;
         },
+        enableSorting: true,
     }),
     columnHelper.accessor((row) => row, {
         id: 'task',
@@ -53,27 +73,68 @@ export const useExpensesTableColumns = () => [
             );
         },
         header: 'Tarea',
+        enableSorting: false,
     }),
     columnHelper.accessor((row) => row.amount, {
         id: 'amount',
-        header: 'Monto',
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full items-center justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span>Monto</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
+        },
         cell: (info) => {
             const amount = info.getValue();
 
             return (
-                <p className="max-w-[250px] text-muted-foreground">
+                <p className="block text-left text-muted-foreground">
                     ${amount.toLocaleString('es-AR')}
                 </p>
             );
         },
+        enableSorting: true,
     }),
     columnHelper.accessor((row) => row.registeredBy, {
         id: 'registeredBy',
         cell: (info) => {
             const expense = info.row.original;
-            return expense.registeredBy.fullName;
+            return (
+                <span className="block text-left">{expense.registeredBy.fullName}</span>
+            );
         },
-        header: 'Registrado por',
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full items-center justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span>Registrado por</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
+        },
+        enableSorting: true,
         filterFn: (row, id, userId: string[]) => {
             if (!userId) {
                 return true;
@@ -87,24 +148,85 @@ export const useExpensesTableColumns = () => [
     }),
     columnHelper.accessor((row) => row.doneBy, {
         id: 'doneBy',
-        header: 'Pagado por',
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full items-center justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span>Pagado por</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
+        },
         cell: (info) => {
             const expense = info.row.original;
-            return expense.doneBy;
+            return <span className="block text-left">{expense.doneBy}</span>;
         },
+        enableSorting: true,
     }),
     columnHelper.accessor((row) => row.expenseDate, {
         id: 'expenseDate',
-        header: 'Fecha de pago',
-        cell: (info) => {
-            const expenseDate = new Date(info.row.original.expenseDate);
-            expenseDate.setHours(0, 0, 0, 0);
-            return format(expenseDate, 'dd/MM/yyyy');
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full items-center justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span>Fecha de pago</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
         },
+        cell: (info) => {
+            const expense = info.row.original;
+            const expenseDate = new Date(expense.expenseDate);
+            expenseDate.setHours(0, 0, 0, 0);
+            return (
+                <span className="block text-left">
+                    {format(expenseDate, 'dd/MM/yyyy')}
+                </span>
+            );
+        },
+        enableSorting: true,
     }),
     columnHelper.accessor((row) => row.expenseType, {
         id: 'expenseType',
-        header: 'Razon',
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full items-center justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span className="ml-2 text-left">Razón</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
+        },
         filterFn: (row, id, types: ExpenseType[]) => {
             if (!types) {
                 return true;
@@ -117,8 +239,13 @@ export const useExpensesTableColumns = () => [
         },
         cell: (info) => {
             const type = info.getValue();
-            return <ExpenseTypeBadge type={type} />;
+            return (
+                <div className="text-left">
+                    <ExpenseTypeBadge type={type} />
+                </div>
+            );
         },
+        enableSorting: true,
     }),
     columnHelper.accessor(
         (row) => ({
@@ -128,7 +255,27 @@ export const useExpensesTableColumns = () => [
         }),
         {
             id: 'paySource',
-            header: 'Fuente de pago',
+            header: ({ column }) => {
+                return (
+                    <button
+                        className="flex w-full items-center justify-between gap-1 text-left"
+                        onClick={() =>
+                            column.toggleSorting(column.getIsSorted() === 'asc')
+                        }
+                    >
+                        <span className="ml-2 text-left">Fuente de pago</span>
+                        {column.getIsSorted() && (
+                            <span>
+                                {column.getIsSorted() === 'asc' ? (
+                                    <ArrowUp className="ml-1 size-4" />
+                                ) : (
+                                    <ArrowDown className="ml-1 size-4" />
+                                )}
+                            </span>
+                        )}
+                    </button>
+                );
+            },
             filterFn: (row, id, paySources: ExpensePaySource[]) => {
                 if (!paySources) {
                     return true;
@@ -144,21 +291,46 @@ export const useExpensesTableColumns = () => [
             cell: (info) => {
                 const { paySource, installments, paySourceBank } = info.getValue();
                 return (
-                    <ExpensePaySourceBadge
-                        paySource={paySource}
-                        installments={installments}
-                        paySourceBank={paySourceBank}
-                    />
+                    <div className="text-left">
+                        <ExpensePaySourceBadge
+                            paySource={paySource}
+                            installments={installments}
+                            paySourceBank={paySourceBank}
+                        />
+                    </div>
                 );
             },
+            enableSorting: true,
         },
     ),
     columnHelper.accessor((row) => row.status, {
         id: 'status',
-        header: 'Estado',
+        header: ({ column }) => {
+            return (
+                <button
+                    className="flex w-full items-center justify-between gap-1 text-left"
+                    onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+                >
+                    <span className="ml-2 text-left">Estado</span>
+                    {column.getIsSorted() && (
+                        <span>
+                            {column.getIsSorted() === 'asc' ? (
+                                <ArrowUp className="ml-1 size-4" />
+                            ) : (
+                                <ArrowDown className="ml-1 size-4" />
+                            )}
+                        </span>
+                    )}
+                </button>
+            );
+        },
         cell: (info) => {
             const status = info.getValue();
-            return <ExpenseStatusBadge status={status} />;
+            return (
+                <div className="text-left">
+                    <ExpenseStatusBadge status={status} />
+                </div>
+            );
         },
         filterFn: (row, id, statuses: ExpenseStatus[]) => {
             if (!statuses?.length) {
@@ -168,6 +340,7 @@ export const useExpensesTableColumns = () => [
             const thisStatus = row.getValue<ExpenseStatus>(id);
             return statuses.includes(thisStatus);
         },
+        enableSorting: true,
     }),
     columnHelper.display({
         id: 'actions',
@@ -176,5 +349,6 @@ export const useExpensesTableColumns = () => [
 
             return <ExpensesTableRowActions expense={expense} />;
         },
+        enableSorting: false,
     }),
 ];

--- a/src/modules/tables/ExpensesDataTable/expenses-table-row-actions.tsx
+++ b/src/modules/tables/ExpensesDataTable/expenses-table-row-actions.tsx
@@ -60,8 +60,8 @@ export function ExpensesTableRowActions({ expense }: Props): JSX.Element {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/ExpensesDataTable/index.tsx
+++ b/src/modules/tables/ExpensesDataTable/index.tsx
@@ -8,6 +8,7 @@ import {
     getSortedRowModel,
 } from '@tanstack/react-table';
 import { useEffect, useState } from 'react';
+import { BsPlus } from 'react-icons/bs';
 
 import { useExpensesTableColumns } from './columns';
 import { getExpensesTableToolbarConfig } from './toolbar-config';
@@ -19,6 +20,7 @@ import {
     GetExpensesQuery,
     GetTechniciansQuery,
 } from '@/api/graphql';
+import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/ui/data-table';
 import { ExpenseReportButton } from '@/components/ui/ExpenseReportButton';
 import { TableSkeleton } from '@/components/ui/skeleton';
@@ -163,9 +165,21 @@ export default function ExpensesDataTable(props: ExpensesDataTableProps): JSX.El
                 router.push(routesBuilder.accounting.expenses.details(row.id))
             }
             headerActions={
-                user.roles.includes('AdministrativoContable') && (
-                    <ExpenseReportButton table={table} />
-                )
+                <>
+                    {user.roles.includes('Auditor') && (
+                        <ExpenseReportButton table={table} />
+                    )}
+                    {(user.roles.includes('AdministrativoContable') ||
+                        user.roles.includes('AdministrativoTecnico')) && (
+                        <Button
+                            className="flex items-center gap-1 pr-6"
+                            onClick={() => router.push('/accounting/expenses/create')}
+                        >
+                            <BsPlus size="20" />
+                            <span>Crear gasto</span>
+                        </Button>
+                    )}
+                </>
             }
         />
     );

--- a/src/modules/tables/ExpensesDataTable/index.tsx
+++ b/src/modules/tables/ExpensesDataTable/index.tsx
@@ -4,6 +4,8 @@ import {
     ColumnFiltersState,
     getCoreRowModel,
     useReactTable,
+    SortingState,
+    getSortedRowModel,
 } from '@tanstack/react-table';
 import { useEffect, useState } from 'react';
 
@@ -37,6 +39,21 @@ export default function ExpensesDataTable(props: ExpensesDataTableProps): JSX.El
         }
         const saved = localStorage.getItem('expensesTableFilters');
         return saved ? JSON.parse(saved) : [];
+    });
+
+    const [sorting, setSorting] = useState<SortingState>(() => {
+        if (typeof window === 'undefined') {
+            return [];
+        }
+        const saved = localStorage.getItem('expensesTableSorting');
+        return saved
+            ? JSON.parse(saved)
+            : [
+                  {
+                      id: 'expenseDate',
+                      desc: true,
+                  },
+              ];
     });
 
     const [page, setPage] = useState(() => {
@@ -77,6 +94,8 @@ export default function ExpensesDataTable(props: ExpensesDataTableProps): JSX.El
         expenseDateTo:
             (columnFilters.find((f) => f.id === 'expenseDate')?.value as { to?: Date })
                 ?.to || null,
+        orderBy: sorting.length > 0 ? sorting[0].id : null,
+        orderDirection: sorting.length > 0 ? (sorting[0].desc ? 'desc' : 'asc') : null,
     });
     const { user } = useUserContext();
     const columns = useExpensesTableColumns();
@@ -84,6 +103,10 @@ export default function ExpensesDataTable(props: ExpensesDataTableProps): JSX.El
     useEffect(() => {
         localStorage.setItem('expensesTableFilters', JSON.stringify(columnFilters));
     }, [columnFilters]);
+
+    useEffect(() => {
+        localStorage.setItem('expensesTableSorting', JSON.stringify(sorting));
+    }, [sorting]);
 
     useEffect(() => {
         localStorage.setItem('expensesTablePage', page.toString());
@@ -97,10 +120,12 @@ export default function ExpensesDataTable(props: ExpensesDataTableProps): JSX.El
         data: data?.expenses || [],
         columns,
         getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
         onColumnFiltersChange: (filters) => {
             setColumnFilters(filters);
             setPage(0);
         },
+        onSortingChange: setSorting,
         state: {
             columnVisibility: {
                 branch: false,
@@ -108,6 +133,7 @@ export default function ExpensesDataTable(props: ExpensesDataTableProps): JSX.El
                 client: false,
             },
             columnFilters,
+            sorting,
         },
     });
 

--- a/src/modules/tables/PreventivesTable/preventives-table-row-actions.tsx
+++ b/src/modules/tables/PreventivesTable/preventives-table-row-actions.tsx
@@ -85,8 +85,8 @@ export function PreventivesTableRowActions({ preventive }: Props): JSX.Element {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/ProvincesDataTable/provinces-table-row-actions.tsx
+++ b/src/modules/tables/ProvincesDataTable/provinces-table-row-actions.tsx
@@ -52,8 +52,8 @@ export function ProvincesTableRowActions({ province }: Props) {
         <div className="flex w-full justify-end">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/ServiceOrdersDataTable/service-orders-table-row-actions.tsx
+++ b/src/modules/tables/ServiceOrdersDataTable/service-orders-table-row-actions.tsx
@@ -32,8 +32,8 @@ export function ServiceOrdersTableRowActions({ serviceOrder }: Props) {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/TaskPricesTable/task-prices-table-row-actions.tsx
+++ b/src/modules/tables/TaskPricesTable/task-prices-table-row-actions.tsx
@@ -28,8 +28,8 @@ export function TaskPricesTableRowActions({ taskPrice }: Props) {
         <div className="flex w-full justify-end">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/TasksDataTable/tasks-table-row-actions.tsx
+++ b/src/modules/tables/TasksDataTable/tasks-table-row-actions.tsx
@@ -85,8 +85,8 @@ export function TasksTableRowActions({ task }: Props): JSX.Element {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="flex h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="flex size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>

--- a/src/modules/tables/UsersDataTable/users-table-row-actions.tsx
+++ b/src/modules/tables/UsersDataTable/users-table-row-actions.tsx
@@ -80,8 +80,8 @@ export function UsersTableRowActions({ user }: Props) {
         <>
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" className="h-8 w-8 p-0">
-                        <DotsHorizontalIcon className="h-4 w-4" />
+                    <Button variant="ghost" className="size-8 p-0">
+                        <DotsHorizontalIcon className="size-4" />
                         <span className="sr-only">Abrir menú</span>
                     </Button>
                 </DropdownMenuTrigger>
@@ -93,7 +93,7 @@ export function UsersTableRowActions({ user }: Props) {
                             }}
                             className="flex items-center gap-2"
                         >
-                            <Pencil className="mr-2 h-4 w-4" />
+                            <Pencil className="size-4" />
                             Editar
                         </div>
                     </DropdownMenuItem>
@@ -104,7 +104,7 @@ export function UsersTableRowActions({ user }: Props) {
                             }}
                             className="flex items-center gap-2"
                         >
-                            <Trash2 className="mr-2 h-4 w-4" />
+                            <Trash2 className="size-4" />
                             Eliminar
                         </div>
                     </DropdownMenuItem>
@@ -115,7 +115,7 @@ export function UsersTableRowActions({ user }: Props) {
                             }}
                             className="flex items-center gap-2"
                         >
-                            <CgPassword className="mr-2 h-4 w-4" />
+                            <CgPassword className="size-4" />
                             Regenerar contraseña
                         </div>
                     </DropdownMenuItem>

--- a/src/pages/accounting/expenses/create.tsx
+++ b/src/pages/accounting/expenses/create.tsx
@@ -1,0 +1,36 @@
+import { Role } from '@prisma/client';
+
+import CreateExpenseForm from '@/components/Forms/Accounting/CreateExpenseForm';
+import { TableSkeleton } from '@/components/ui/skeleton';
+import { useUserContext } from '@/context/userContext/UserProvider';
+import { useGetTechnicians } from '@/hooks/api/user/useGetTechnicians';
+
+export default function CreateExpense(): JSX.Element {
+    const { user } = useUserContext();
+    const { data: techniciansData, isLoading } = useGetTechnicians({});
+
+    if (isLoading) {
+        return <TableSkeleton />;
+    }
+
+    // Verificar que el usuario tenga el rol necesario
+    if (
+        !user.roles?.includes(Role.AdministrativoContable) &&
+        !user.roles?.includes(Role.AdministrativoTecnico)
+    ) {
+        return (
+            <main className="flex h-[calc(100vh-4rem)] items-center justify-center">
+                <div className="text-center">
+                    <h1 className="text-2xl font-bold text-destructive">
+                        Acceso denegado
+                    </h1>
+                    <p className="mt-2 text-muted-foreground">
+                        No tienes permisos para acceder a esta página.
+                    </p>
+                </div>
+            </main>
+        );
+    }
+
+    return <CreateExpenseForm techs={techniciansData?.technicians || []} />;
+}

--- a/src/pages/accounting/expenses/index.tsx
+++ b/src/pages/accounting/expenses/index.tsx
@@ -15,7 +15,8 @@ export default function Expenses(): JSX.Element {
 
     return (
         <main>
-            {user.roles?.includes(Role.AdministrativoContable) ? (
+            {user.roles?.includes(Role.AdministrativoContable) ||
+            user.roles?.includes(Role.AdministrativoTecnico) ? (
                 <ExpensesDataTable techs={techniciansData?.technicians || []} />
             ) : (
                 <div>No tienes permisos para ver esta página</div>

--- a/src/pages/api/upload-file.ts
+++ b/src/pages/api/upload-file.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+// Inicializar el cliente S3
+const s3Client = new S3Client({
+    region: process.env.AWS_REGION,
+    credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID as string,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY as string,
+    },
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    // Solo permitir solicitudes POST
+    if (req.method !== 'POST') {
+        return res.status(405).json({ error: 'Método no permitido' });
+    }
+
+    try {
+        // Verificar y parsear los datos de la solicitud
+        const { file, contentType, key, expenseId } = req.body;
+
+        if (!file || !contentType || !key) {
+            return res.status(400).json({ error: 'Faltan parámetros requeridos' });
+        }
+
+        // Log para diagnóstico
+        console.log(`Subiendo archivo para el gasto ID: ${expenseId || 'no disponible'}`);
+        console.log(`Key de archivo: ${key}`);
+
+        // Verificar que la key contenga el ID del gasto (si se proporciona)
+        if (expenseId && !key.includes(expenseId)) {
+            console.warn(
+                `Advertencia: La key del archivo (${key}) no contiene el ID del gasto (${expenseId})`,
+            );
+        }
+
+        // Decodificar el archivo base64
+        const fileBuffer = Buffer.from(file.split(',')[1], 'base64');
+
+        // Construir el comando para subir a S3
+        const command = new PutObjectCommand({
+            Bucket: process.env.AWS_S3_BUCKET_NAME as string,
+            Key: key,
+            Body: fileBuffer,
+            ContentType: contentType,
+        });
+
+        // Enviar el archivo a S3
+        await s3Client.send(command);
+
+        // Log de éxito
+        console.log(`Archivo subido correctamente a S3 con key: ${key}`);
+
+        // Devolver respuesta exitosa
+        return res.status(200).json({
+            success: true,
+            key,
+            message: 'Archivo subido correctamente',
+            expenseId: expenseId || null,
+        });
+    } catch (error) {
+        console.error('Error al subir archivo a S3:', error);
+        return res.status(500).json({
+            success: false,
+            error: error instanceof Error ? error.message : 'Error desconocido',
+        });
+    }
+}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -19,7 +19,7 @@ export default function AuthenticationPage() {
                 logoutUser();
             });
         }
-    }, [query]);
+    }, [query, logoutMutation, logoutUser]);
 
     return (
         <main className="container relative flex min-h-screen items-center justify-center">

--- a/src/pages/tasks/[id]/expenses/create.tsx
+++ b/src/pages/tasks/[id]/expenses/create.tsx
@@ -1,0 +1,66 @@
+import { useRouter } from 'next/router';
+
+import { Role } from '@prisma/client';
+
+import CreateExpenseForm from '@/components/Forms/Accounting/CreateExpenseForm';
+import { TableSkeleton } from '@/components/ui/skeleton';
+import { useUserContext } from '@/context/userContext/UserProvider';
+import { useGetTask } from '@/hooks/api/task/useGetTask';
+import { useGetTechnicians } from '@/hooks/api/user/useGetTechnicians';
+
+export default function CreateTaskExpense(): JSX.Element {
+    const router = useRouter();
+    const { id: taskId } = router.query;
+
+    const { user } = useUserContext();
+    const { data: techniciansData, isLoading: isLoadingTechs } = useGetTechnicians({});
+    const { data: taskData, isLoading: isLoadingTask } = useGetTask({
+        id: taskId as string,
+    });
+
+    if (isLoadingTechs || isLoadingTask) {
+        return <TableSkeleton />;
+    }
+
+    // Verificar que el usuario tenga el rol necesario
+    if (
+        !user.roles?.includes(Role.AdministrativoContable) &&
+        !user.roles?.includes(Role.AdministrativoTecnico)
+    ) {
+        return (
+            <main className="flex h-[calc(100vh-4rem)] items-center justify-center">
+                <div className="text-center">
+                    <h1 className="text-2xl font-bold text-destructive">
+                        Acceso denegado
+                    </h1>
+                    <p className="mt-2 text-muted-foreground">
+                        No tienes permisos para acceder a esta página.
+                    </p>
+                </div>
+            </main>
+        );
+    }
+
+    // Verificar que la tarea existe
+    if (!taskData?.taskById) {
+        return (
+            <main className="flex h-[calc(100vh-4rem)] items-center justify-center">
+                <div className="text-center">
+                    <h1 className="text-2xl font-bold text-destructive">
+                        Tarea no encontrada
+                    </h1>
+                    <p className="mt-2 text-muted-foreground">
+                        La tarea que estás buscando no existe o ha sido eliminada.
+                    </p>
+                </div>
+            </main>
+        );
+    }
+
+    return (
+        <CreateExpenseForm
+            taskId={taskId as string}
+            techs={techniciansData?.technicians || []}
+        />
+    );
+}


### PR DESCRIPTION
### Crear un formulario para cargar gastos desde la web
## Frontend
Implementación de un formulario para cargar gastos desde la aplicación web con los siguientes campos:

**Monto:** Campo numérico
**Tipo de gasto:** Menú desplegable (tipo ExpenseType)
**Fuente de pago:** Menú desplegable (tipo PaySource)
**Banco emisor:** Menú desplegable opcional que aparece solo cuando la fuente de pago es Crédito o Débito (tipo PaySourceBank)
**Cuotas:** Campo numérico opcional que aparece cuando la fuente de pago seleccionada es Crédito (campo installments)
**Fecha de pago:** Calendario con fecha seleccionable (similar al filtro de fechas de la tabla de gastos)
**Pagado por:** Menú desplegable con técnicos disponibles más opción "Otro"

Al seleccionar "Otro" aparece un campo para ingresar el nombre


**Ciudad de compra:** Menú desplegable con opciones limitadas (Trelew, Rawson, Madryn, Comodoro, Esquel) más opción "Otro"

Al seleccionar "Otro" aparece un campo para ingresar el nombre de la ciudad


**Observaciones:** Campo de texto
**Archivos adjuntos:** Botón para subir hasta 5 fotos o archivos

Los archivos se cargarán a S3 y se enviarán las keys al backend



### Acceso y ubicación

Botones para acceder al formulario visibles solo para usuarios con rol "Administrativo contable"
Ubicación de los botones:

En la tabla de gastos
En el detalle de la tarea (cuando se crea desde la tarea, se enviará el ID de la tarea al backend para asociarlos)


### Integración

Agregar la mutation de GraphQL (se puede copiar del repositorio de la aplicación móvil, ubicación: src/api/documents/expenses.graphql)

## Backend

Modificar el resolver existente para crear gastos, cambiando las reglas de acceso para permitir la creación por parte de usuarios con rol "Administrativo Contable"