### PR TITLE
Bugfix | Expenses Auth Rules

### DIFF
--- a/backend/schema/resolvers/expense/mutations.ts
+++ b/backend/schema/resolvers/expense/mutations.ts
@@ -56,7 +56,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
             compositeRules: [
                 { and: ['IsAuthenticated'] },
                 {
-                    or: ['IsTecnico', 'IsAdministrativoContable', 'IsAuditor'],
+                    or: ['IsTecnico', 'IsAdministrativoContable'],
                 },
             ],
         },
@@ -135,7 +135,7 @@ export const ExpenseMutations = builder.mutationFields((t) => ({
             compositeRules: [
                 { and: ['IsAuthenticated'] },
                 {
-                    or: ['IsAdministrativoContable', 'IsAdministrativoTecnico'],
+                    or: ['IsAdministrativoContable', 'IsTecnico'],
                 },
             ],
         },


### PR DESCRIPTION
fixed auth rules, where it allowed technical administrators to create expenses, but not technicians