### PR TITLE
Bugfix | Branch name

### DIFF
--- a/backend/schema/resolvers/preventive/queries.ts
+++ b/backend/schema/resolvers/preventive/queries.ts
@@ -52,14 +52,18 @@ export const PreventiveQueries = builder.queryFields((t) => ({
                     ...(filters.business?.length && {
                         businessId: { in: filters.business },
                     }),
-                    ...(filters.city?.length && {
-                        branch: { cityId: { in: filters.city } },
+                    ...((filters.city?.length || filters.client?.length) && {
+                        branch: {
+                            ...(filters.city?.length && {
+                                cityId: { in: filters.city },
+                            }),
+                            ...(filters.client?.length && {
+                                clientId: { in: filters.client },
+                            }),
+                        },
                     }),
                     ...(filters.assigned?.length && {
                         assignedIDs: { hasSome: filters.assigned },
-                    }),
-                    ...(filters.client?.length && {
-                        branch: { clientId: { in: filters.client } },
                     }),
                     ...(filters.frequency?.length && {
                         frequency: { in: filters.frequency },
@@ -116,14 +120,18 @@ export const PreventiveQueries = builder.queryFields((t) => ({
                     ...(filters.business?.length && {
                         businessId: { in: filters.business },
                     }),
-                    ...(filters.city?.length && {
-                        branch: { cityId: { in: filters.city } },
+                    ...((filters.city?.length || filters.client?.length) && {
+                        branch: {
+                            ...(filters.city?.length && {
+                                cityId: { in: filters.city },
+                            }),
+                            ...(filters.client?.length && {
+                                clientId: { in: filters.client },
+                            }),
+                        },
                     }),
                     ...(filters.assigned?.length && {
                         assignedIDs: { hasSome: filters.assigned },
-                    }),
-                    ...(filters.client?.length && {
-                        branch: { clientId: { in: filters.client } },
                     }),
                     ...(filters.frequency?.length && {
                         frequency: { in: filters.frequency },

--- a/backend/schema/resolvers/task/queries.ts
+++ b/backend/schema/resolvers/task/queries.ts
@@ -100,11 +100,15 @@ builder.queryFields((t) => ({
                             ...(filters.business?.length && {
                                 businessId: { in: filters.business },
                             }),
-                            ...(filters.city?.length && {
-                                branch: { cityId: { in: filters.city } },
-                            }),
-                            ...(filters.client?.length && {
-                                branch: { clientId: { in: filters.client } },
+                            ...((filters.city?.length || filters.client?.length) && {
+                                branch: {
+                                    ...(filters.city?.length && {
+                                        cityId: { in: filters.city },
+                                    }),
+                                    ...(filters.client?.length && {
+                                        clientId: { in: filters.client },
+                                    }),
+                                },
                             }),
                             ...(filters.assigned?.length && {
                                 assignedIDs: { hasSome: filters.assigned },
@@ -170,11 +174,15 @@ builder.queryFields((t) => ({
                     ...(filters.business?.length && {
                         businessId: { in: filters.business },
                     }),
-                    ...(filters.city?.length && {
-                        branch: { cityId: { in: filters.city } },
-                    }),
-                    ...(filters.client?.length && {
-                        branch: { clientId: { in: filters.client } },
+                    ...((filters.city?.length || filters.client?.length) && {
+                        branch: {
+                            ...(filters.city?.length && {
+                                cityId: { in: filters.city },
+                            }),
+                            ...(filters.client?.length && {
+                                clientId: { in: filters.client },
+                            }),
+                        },
                     }),
                     ...(filters.assigned?.length && {
                         assignedIDs: { hasSome: filters.assigned },
@@ -256,13 +264,16 @@ builder.queryFields((t) => ({
                     ...(filters.business?.length && {
                         businessId: { in: filters.business },
                     }),
-                    ...(filters.city?.length && {
-                        branch: { cityId: { in: filters.city } },
+                    ...((filters.city?.length || filters.client?.length) && {
+                        branch: {
+                            ...(filters.city?.length && {
+                                cityId: { in: filters.city },
+                            }),
+                            ...(filters.client?.length && {
+                                clientId: { in: filters.client },
+                            }),
+                        },
                     }),
-                    ...(filters.client?.length && {
-                        branch: { clientId: { in: filters.client } },
-                    }),
-
                     ...(filters.assigned?.length && {
                         assignedIDs: { hasSome: filters.assigned },
                     }),

--- a/src/api/documents/client.graphql
+++ b/src/api/documents/client.graphql
@@ -42,6 +42,7 @@ query GetClientsWithBranches {
         branches {
             id
             number
+            name
             businesses {
                 id
                 name

--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -1297,6 +1297,7 @@ export type GetClientsWithBranchesQuery = {
             __typename?: 'Branch';
             id: string;
             number: number | null;
+            name: string | null;
             businesses: Array<{ __typename?: 'Business'; id: string; name: string }>;
             city: { __typename?: 'City'; id: string; name: string };
         }>;
@@ -4092,6 +4093,10 @@ export const GetClientsWithBranchesDocument = {
                                             {
                                                 kind: 'Field',
                                                 name: { kind: 'Name', value: 'number' },
+                                            },
+                                            {
+                                                kind: 'Field',
+                                                name: { kind: 'Name', value: 'name' },
                                             },
                                             {
                                                 kind: 'Field',

--- a/src/components/Forms/TechAdmin/ClientBranchForm.tsx
+++ b/src/components/Forms/TechAdmin/ClientBranchForm.tsx
@@ -67,7 +67,7 @@ export default function ClientBranchForm({
             return fetchClient(CreateBranchDocument, data);
         },
         onSuccess: () => {
-            router.push('/tech-admin/cities');
+            router.push(routesBuilder.branches.list(client.id));
             triggerAlert({
                 type: 'Success',
                 message: `Se creó la sucursal correctamente`,
@@ -87,7 +87,7 @@ export default function ClientBranchForm({
             return fetchClient(UpdateBranchDocument, data);
         },
         onSuccess: () => {
-            router.push(`/tech-admin/clients/${client.id}/branches`);
+            router.push(routesBuilder.branches.list(client.id));
             triggerAlert({
                 type: 'Success',
                 message: `Se actualizó la sucursal correctamente`,

--- a/src/components/Forms/TechAdmin/CreateOrUpdatePreventiveForm.tsx
+++ b/src/components/Forms/TechAdmin/CreateOrUpdatePreventiveForm.tsx
@@ -238,7 +238,9 @@ const CreateOrUpdatePreventiveForm = ({
         clients
             .find((client) => client.id === form.watch('client'))
             ?.branches.map((branch) => ({
-                label: `${branch.number}, ${branch.city.name}`,
+                label: `${branch.number ? `${branch.number} - ` : ''}${
+                    branch.name ? `${branch.name} - ` : ''
+                }${branch.city.name}`,
                 value: branch.id,
             })) || [];
 


### PR DESCRIPTION
Fixed a bug where the filters for client and city in the preventives table would not apply correctly and just apply the client filter. Fixed the display of branches in the preventives form.
Fixed a routing issue where when creating a branch, on success it would reroute to the cities lists