### PR TITLE
Hotfix | Task Report Finalized Status

### DIFF
--- a/backend/schema/resolvers/task/mutations.ts
+++ b/backend/schema/resolvers/task/mutations.ts
@@ -1068,7 +1068,8 @@ builder.mutationFields((t) => ({
                 // Construir la cláusula where
                 const whereClause = {
                     deleted: false,
-                    status: TaskStatus.Aprobada, // Solo tareas aprobadas
+                    // Incluir tareas Aprobada y Finalizada
+                    status: { in: [TaskStatus.Aprobada, TaskStatus.Finalizada] },
                     closedAt: {
                         gte: startDate,
                         lte: endDate,


### PR DESCRIPTION
changed the where clause on the generate approved task report to also print out the finalized tasks